### PR TITLE
x86 compatibility

### DIFF
--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,0 +1,5 @@
+#[cfg(target_arch = "x86_64")]
+pub type faiss_usize = i64;
+
+#[cfg(target_arch = "x86")]
+pub type faiss_usize = i32;

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,5 +1,21 @@
-#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
+#[cfg(
+    any(
+	target_arch = "x86_64",
+	target_arch = "aarch64",
+	target_arch = "powerpc64",
+	target_arch = "mips64",
+	target_arch = "nvptx"
+    )
+)]
 pub type faiss_usize = i64;
 
-#[cfg(target_arch = "x86")]
+#[cfg(
+    any(
+	target_arch = "x86",
+	target_arch = "arm",
+	target_arch = "powerpc",
+	target_arch = "mips",
+	target_arch = "wasm32"
+    )
+)]
 pub type faiss_usize = i32;

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,4 +1,4 @@
-#[cfg(any(target_arch = "arm", target_arch = "x86_64"))]
+#[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
 pub type faiss_usize = i64;
 
 #[cfg(target_arch = "x86")]

--- a/src/arch.rs
+++ b/src/arch.rs
@@ -1,4 +1,4 @@
-#[cfg(target_arch = "x86_64")]
+#[cfg(any(target_arch = "arm", target_arch = "x86_64"))]
 pub type faiss_usize = i64;
 
 #[cfg(target_arch = "x86")]

--- a/src/index/flat.rs
+++ b/src/index/flat.rs
@@ -139,7 +139,7 @@ impl ConcurrentIndex for FlatIndexImpl {
                 nq as idx_t,
                 query.as_ptr(),
                 out_labels.as_mut_ptr() as *mut _,
-                k as i64
+                k as crate::arch::faiss_usize
             ));
             Ok(AssignSearchResult { labels: out_labels })
         }

--- a/src/index/gpu.rs
+++ b/src/index/gpu.rs
@@ -171,7 +171,7 @@ where
     fn add(&mut self, x: &[f32]) -> Result<()> {
         unsafe {
             let n = x.len() / self.d() as usize;
-            faiss_try!(faiss_Index_add(self.inner, n as i64, x.as_ptr()));
+            faiss_try!(faiss_Index_add(self.inner, n as crate::arch::faiss_usize, x.as_ptr()));
             Ok(())
         }
     }
@@ -181,7 +181,7 @@ where
             let n = x.len() / self.d() as usize;
             faiss_try!(faiss_Index_add_with_ids(
                 self.inner,
-                n as i64,
+                n as crate::arch::faiss_usize,
                 x.as_ptr(),
                 xids.as_ptr() as *const _
             ));
@@ -192,7 +192,7 @@ where
     fn train(&mut self, x: &[f32]) -> Result<()> {
         unsafe {
             let n = x.len() / self.d() as usize;
-            faiss_try!(faiss_Index_train(self.inner, n as i64, x.as_ptr()));
+            faiss_try!(faiss_Index_train(self.inner, n as crate::arch::faiss_usize, x.as_ptr()));
             Ok(())
         }
     }
@@ -206,7 +206,7 @@ where
                 nq as idx_t,
                 query.as_ptr(),
                 out_labels.as_mut_ptr() as *mut _,
-                k as i64
+                k as crate::arch::faiss_usize
             ));
             Ok(AssignSearchResult { labels: out_labels })
         }
@@ -252,7 +252,7 @@ where
         }
     }
 
-    fn remove_ids(&mut self, sel: &IdSelector) -> Result<i64> {
+    fn remove_ids(&mut self, sel: &IdSelector) -> Result<crate::arch::faiss_usize> {
         unsafe {
             let mut n_removed = 0;
             faiss_try!(faiss_Index_remove_ids(

--- a/src/index/id_map.rs
+++ b/src/index/id_map.rs
@@ -174,7 +174,7 @@ impl<I> Index for IdMap<I> {
     fn add(&mut self, x: &[f32]) -> Result<()> {
         unsafe {
             let n = x.len() / self.d() as usize;
-            faiss_try!(faiss_Index_add(self.inner_ptr(), n as i64, x.as_ptr()));
+            faiss_try!(faiss_Index_add(self.inner_ptr(), n as crate::arch::faiss_usize, x.as_ptr()));
             Ok(())
         }
     }
@@ -184,7 +184,7 @@ impl<I> Index for IdMap<I> {
             let n = x.len() / self.d() as usize;
             faiss_try!(faiss_Index_add_with_ids(
                 self.inner_ptr(),
-                n as i64,
+                n as crate::arch::faiss_usize,
                 x.as_ptr(),
                 xids.as_ptr() as *const _
             ));
@@ -194,7 +194,7 @@ impl<I> Index for IdMap<I> {
     fn train(&mut self, x: &[f32]) -> Result<()> {
         unsafe {
             let n = x.len() / self.d() as usize;
-            faiss_try!(faiss_Index_train(self.inner_ptr(), n as i64, x.as_ptr()));
+            faiss_try!(faiss_Index_train(self.inner_ptr(), n as crate::arch::faiss_usize, x.as_ptr()));
             Ok(())
         }
     }
@@ -207,7 +207,7 @@ impl<I> Index for IdMap<I> {
                 nq as idx_t,
                 query.as_ptr(),
                 out_labels.as_mut_ptr() as *mut _,
-                k as i64
+                k as crate::arch::faiss_usize
             ));
             Ok(AssignSearchResult { labels: out_labels })
         }
@@ -251,7 +251,7 @@ impl<I> Index for IdMap<I> {
         }
     }
 
-    fn remove_ids(&mut self, sel: &IdSelector) -> Result<(i64)> {
+    fn remove_ids(&mut self, sel: &IdSelector) -> Result<(crate::arch::faiss_usize)> {
         unsafe {
             let mut n_removed = 0;
             faiss_try!(faiss_Index_remove_ids(
@@ -277,7 +277,7 @@ where
                 nq as idx_t,
                 query.as_ptr(),
                 out_labels.as_mut_ptr() as *mut _,
-                k as i64
+                k as crate::arch::faiss_usize
             ));
             Ok(AssignSearchResult { labels: out_labels })
         }

--- a/src/index/lsh.rs
+++ b/src/index/lsh.rs
@@ -129,7 +129,7 @@ impl ConcurrentIndex for LshIndex {
                 nq as idx_t,
                 query.as_ptr(),
                 out_labels.as_mut_ptr() as *mut _,
-                k as i64
+                k as crate::arch::faiss_usize
             ));
             Ok(AssignSearchResult { labels: out_labels })
         }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -171,7 +171,7 @@ pub trait Index {
     fn reset(&mut self) -> Result<()>;
 
     /// Remove data vectors represented by IDs.
-    fn remove_ids(&mut self, sel: &IdSelector) -> Result<i64>;
+    fn remove_ids(&mut self, sel: &IdSelector) -> Result<crate::arch::faiss_usize>;
 }
 
 /// Sub-trait for native implementations of a Faiss index.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,6 +91,7 @@ pub mod cluster;
 pub mod error;
 pub mod index;
 pub mod metric;
+pub mod arch;
 pub mod selector;
 
 #[cfg(feature = "gpu")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -35,7 +35,7 @@ macro_rules! impl_native_index {
             fn add(&mut self, x: &[f32]) -> Result<()> {
                 unsafe {
                     let n = x.len() / self.d() as usize;
-                    faiss_try!(faiss_Index_add(self.inner_ptr(), n as i64, x.as_ptr()));
+                    faiss_try!(faiss_Index_add(self.inner_ptr(), n as crate::arch::faiss_usize, x.as_ptr()));
                     Ok(())
                 }
             }
@@ -45,7 +45,7 @@ macro_rules! impl_native_index {
                     let n = x.len() / self.d() as usize;
                     faiss_try!(faiss_Index_add_with_ids(
                         self.inner_ptr(),
-                        n as i64,
+                        n as crate::arch::faiss_usize,
                         x.as_ptr(),
                         xids.as_ptr() as *const _
                     ));
@@ -55,7 +55,7 @@ macro_rules! impl_native_index {
             fn train(&mut self, x: &[f32]) -> Result<()> {
                 unsafe {
                     let n = x.len() / self.d() as usize;
-                    faiss_try!(faiss_Index_train(self.inner_ptr(), n as i64, x.as_ptr()));
+                    faiss_try!(faiss_Index_train(self.inner_ptr(), n as crate::arch::faiss_usize, x.as_ptr()));
                     Ok(())
                 }
             }
@@ -72,7 +72,7 @@ macro_rules! impl_native_index {
                         nq as idx_t,
                         query.as_ptr(),
                         out_labels.as_mut_ptr() as *mut _,
-                        k as i64
+                        k as crate::arch::faiss_usize
                     ));
                     Ok(crate::index::AssignSearchResult { labels: out_labels })
                 }
@@ -120,7 +120,7 @@ macro_rules! impl_native_index {
                 }
             }
 
-            fn remove_ids(&mut self, sel: &IdSelector) -> Result<i64> {
+            fn remove_ids(&mut self, sel: &IdSelector) -> Result<crate::arch::faiss_usize> {
                 unsafe {
                     let mut n_removed = 0;
                     faiss_try!(faiss_Index_remove_ids(


### PR DESCRIPTION
faiss-rs does not work on the x86 platform. This fix allows you to build faiss-rs on x86 and x86_64 platforms