### PR TITLE
Update error handling

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -1,6 +1,7 @@
 //! Vector clustering interface and implementation.
 
 use crate::error::Result;
+use crate::faiss_try;
 use crate::index::NativeIndex;
 use faiss_sys::*;
 use std::os::raw::c_int;
@@ -175,7 +176,7 @@ impl Clustering {
             let d = d as c_int;
             let k = k as c_int;
             let mut inner: *mut FaissClustering = ptr::null_mut();
-            faiss_try!(faiss_Clustering_new(&mut inner, d, k));
+            faiss_try(faiss_Clustering_new(&mut inner, d, k))?;
             Ok(Clustering { inner })
         }
     }
@@ -188,12 +189,12 @@ impl Clustering {
             let d = d as c_int;
             let k = k as c_int;
             let mut inner: *mut FaissClustering = ptr::null_mut();
-            faiss_try!(faiss_Clustering_new_with_params(
+            faiss_try(faiss_Clustering_new_with_params(
                 &mut inner,
                 d,
                 k,
-                &params.inner
-            ));
+                &params.inner,
+            ))?;
             Ok(Clustering { inner })
         }
     }
@@ -208,12 +209,12 @@ impl Clustering {
     {
         unsafe {
             let n = x.len() / self.d() as usize;
-            faiss_try!(faiss_Clustering_train(
+            faiss_try(faiss_Clustering_train(
                 self.inner,
                 n as idx_t,
                 x.as_ptr(),
-                index.inner_ptr()
-            ));
+                index.inner_ptr(),
+            ))?;
             Ok(())
         }
     }
@@ -357,14 +358,14 @@ pub fn kmeans_clustering(d: u32, k: u32, x: &[f32]) -> Result<KMeansResult> {
         let n = x.len() / d as usize;
         let mut centroids = vec![0_f32; (d * k) as usize];
         let mut q_error: f32 = 0.;
-        faiss_try!(faiss_kmeans_clustering(
+        faiss_try(faiss_kmeans_clustering(
             d as usize,
             n,
             k as usize,
             x.as_ptr(),
             centroids.as_mut_ptr(),
-            &mut q_error
-        ));
+            &mut q_error,
+        ))?;
         Ok(KMeansResult { centroids, q_error })
     }
 }

--- a/src/gpu.rs
+++ b/src/gpu.rs
@@ -1,6 +1,7 @@
 //! Contents for GPU support
 
 use crate::error::Result;
+use crate::faiss_try;
 use faiss_sys::*;
 use std::ptr;
 
@@ -97,7 +98,7 @@ impl StandardGpuResources {
     pub fn new() -> Result<Self> {
         unsafe {
             let mut ptr = ptr::null_mut();
-            faiss_try!(faiss_StandardGpuResources_new(&mut ptr));
+            faiss_try(faiss_StandardGpuResources_new(&mut ptr))?;
             Ok(StandardGpuResources { inner: ptr })
         }
     }
@@ -110,21 +111,21 @@ impl GpuResources for StandardGpuResources {
 
     fn no_temp_memory(&mut self) -> Result<()> {
         unsafe {
-            faiss_try!(faiss_StandardGpuResources_noTempMemory(self.inner));
+            faiss_try(faiss_StandardGpuResources_noTempMemory(self.inner))?;
             Ok(())
         }
     }
 
     fn set_temp_memory(&mut self, size: usize) -> Result<()> {
         unsafe {
-            faiss_try!(faiss_StandardGpuResources_setTempMemory(self.inner, size));
+            faiss_try(faiss_StandardGpuResources_setTempMemory(self.inner, size))?;
             Ok(())
         }
     }
 
     fn set_pinned_memory(&mut self, size: usize) -> Result<()> {
         unsafe {
-            faiss_try!(faiss_StandardGpuResources_setPinnedMemory(self.inner, size));
+            faiss_try(faiss_StandardGpuResources_setPinnedMemory(self.inner, size))?;
             Ok(())
         }
     }

--- a/src/index/io.rs
+++ b/src/index/io.rs
@@ -1,6 +1,7 @@
 //! Index I/O functions
 
 use crate::error::{Error, Result};
+use crate::faiss_try;
 use crate::index::{CpuIndex, FromInnerPtr, IndexImpl, NativeIndex};
 use faiss_sys::*;
 use std::ffi::CString;
@@ -22,7 +23,7 @@ where
         let f = file_name.as_ref();
         let f = CString::new(f).map_err(|_| Error::BadFilePath)?;
 
-        faiss_try!(faiss_write_index_fname(index.inner_ptr(), f.as_ptr()));
+        faiss_try(faiss_write_index_fname(index.inner_ptr(), f.as_ptr()))?;
         Ok(())
     }
 }
@@ -41,7 +42,7 @@ where
         let f = file_name.as_ref();
         let f = CString::new(f).map_err(|_| Error::BadFilePath)?;
         let mut inner = ptr::null_mut();
-        faiss_try!(faiss_read_index_fname(f.as_ptr(), 0, &mut inner));
+        faiss_try(faiss_read_index_fname(f.as_ptr(), 0, &mut inner))?;
         Ok(IndexImpl::from_inner_ptr(inner))
     }
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -11,6 +11,7 @@
 //! [`index_factory`]: fn.index_factory.html
 
 use crate::error::{Error, Result};
+use crate::faiss_try;
 use crate::metric::MetricType;
 use crate::selector::IdSelector;
 use std::ffi::CString;
@@ -372,12 +373,12 @@ where
         let description =
             CString::new(description.as_ref()).map_err(|_| Error::IndexDescription)?;
         let mut index_ptr = ::std::ptr::null_mut();
-        faiss_try!(faiss_index_factory(
+        faiss_try(faiss_index_factory(
             &mut index_ptr,
             (d & 0x7FFF_FFFF) as i32,
             description.as_ptr(),
-            metric
-        ));
+            metric,
+        ))?;
         Ok(IndexImpl { inner: index_ptr })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,3 +107,11 @@ pub use metric::MetricType;
 pub use gpu::{GpuResources, StandardGpuResources};
 #[cfg(feature = "gpu")]
 pub use index::gpu::GpuIndexImpl;
+
+pub(crate) fn faiss_try(code: std::os::raw::c_int) -> Result<(), crate::error::NativeError> {
+    if code != 0 {
+        Err(crate::error::NativeError::from_last_error(code))
+    } else {
+        Ok(())
+    }
+}

--- a/src/selector.rs
+++ b/src/selector.rs
@@ -1,5 +1,6 @@
 //! Abstract Faiss ID selector
 use crate::error::Result;
+use crate::faiss_try;
 use crate::index::Idx;
 use faiss_sys::*;
 use std::ptr;
@@ -15,11 +16,11 @@ impl IdSelector {
     pub fn range(min: Idx, max: Idx) -> Result<Self> {
         let mut p_sel = ptr::null_mut();
         unsafe {
-            faiss_try!(faiss_IDSelectorRange_new(
+            faiss_try(faiss_IDSelectorRange_new(
                 &mut p_sel,
                 min.to_native(),
-                max.to_native()
-            ));
+                max.to_native(),
+            ))?;
         };
         Ok(IdSelector {
             inner: p_sel as *mut _,
@@ -31,11 +32,11 @@ impl IdSelector {
         let n = indices.len();
         let mut p_sel = ptr::null_mut();
         unsafe {
-            faiss_try!(faiss_IDSelectorBatch_new(
+            faiss_try(faiss_IDSelectorBatch_new(
                 &mut p_sel,
                 n,
-                indices.as_ptr() as *const _
-            ));
+                indices.as_ptr() as *const _,
+            ))?;
         };
         Ok(IdSelector {
             inner: p_sel as *mut _,


### PR DESCRIPTION
- Replaced `faiss_try!` macro with a `faiss_try` function; using macros for error handling was only really necessary before the try operator, and should be an anti-pattern at this point.
- Removed the deprecated error description method: consumers should be printing errors via the `Display` impl.
- changed the visibility of `NativeError::from_last_error` to pub(crate), as it only makes sense for this crate to construct these errors.