### PR TITLE
Make `TryFromInnerPtr::try_from_inner_ptr` unsafe

### DIFF
--- a/src/index/flat.rs
+++ b/src/index/flat.rs
@@ -127,10 +127,13 @@ impl FromInnerPtr for FlatIndexImpl {
 }
 
 impl TryFromInnerPtr for FlatIndexImpl {
-    fn try_from_inner_ptr(inner_ptr: *mut FaissIndex) -> Result<Self>
+    unsafe fn try_from_inner_ptr(inner_ptr: *mut FaissIndex) -> Result<Self>
     where
         Self: Sized,
     {
+        // safety: `inner_ptr` is documented to be a valid pointer to an index,
+        // so the dynamic cast should be safe.
+        #[allow(unused_unsafe)]
         unsafe {
             let new_inner = faiss_IndexFlat_cast(inner_ptr);
             if new_inner.is_null() {

--- a/src/index/id_map.rs
+++ b/src/index/id_map.rs
@@ -150,6 +150,7 @@ where
             // make id map disown the index
             faiss_IndexIDMap_set_own_fields(self.inner, 0);
             // now it's safe to build a managed index
+            // (`index_inner` is expected to always point to a valid index)
             I::from_inner_ptr(self.index_inner)
         }
     }
@@ -164,6 +165,7 @@ where
             // make id map disown the index
             faiss_IndexIDMap_set_own_fields(self.inner, 0);
             // now it's safe to build a managed index
+            // (`index_inner` is expected to always point to a valid index)
             I::try_from_inner_ptr(self.index_inner)
         }
     }
@@ -173,7 +175,11 @@ where
     where
         B: index::TryFromInnerPtr,
     {
-        if let Ok(index) = B::try_from_inner_ptr(self.index_inner) {
+        // safety: index_inner is expected to always point to a valid index
+        let r = unsafe {
+            B::try_from_inner_ptr(self.index_inner)
+        };
+        if let Ok(index) = r {
             let res = IdMap {
                 inner: self.inner,
                 index_inner: index.inner_ptr(),

--- a/src/index/lsh.rs
+++ b/src/index/lsh.rs
@@ -42,10 +42,13 @@ impl FromInnerPtr for LshIndex {
 }
 
 impl TryFromInnerPtr for LshIndex {
-    fn try_from_inner_ptr(inner_ptr: *mut FaissIndex) -> Result<Self>
+    unsafe fn try_from_inner_ptr(inner_ptr: *mut FaissIndex) -> Result<Self>
     where
         Self: Sized,
     {
+        // safety: `inner_ptr` is documented to be a valid pointer to an index,
+        // so the dynamic cast should be safe.
+        #[allow(unused_unsafe)]
         unsafe {
             let new_inner = faiss_IndexLSH_cast(inner_ptr);
             if new_inner.is_null() {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -318,7 +318,20 @@ pub trait FromInnerPtr: NativeIndex {
 /// Trait for Faiss index types which can be built from a pointer
 /// to a native implementation.
 pub trait TryFromInnerPtr: NativeIndex {
-    fn try_from_inner_ptr(inner_ptr: *mut FaissIndex) -> Result<Self>
+
+    /// Create an index using the given pointer to a native object,
+    /// checking that the index behind the given pointer
+    /// is compatible with the target index type.
+    /// If the inner index is not compatible with the intended target type
+    /// (e.g. creating a `FlatIndex` out of a `FaissIndexLSH`),
+    /// an error is returned.
+    ///
+    /// # Safety
+    ///
+    /// This function is unable to check that
+    /// `inner_ptr` points to a valid, non-freed CPU index.
+    /// Moreover, `inner_ptr` must not be shared across multiple instances.
+    unsafe fn try_from_inner_ptr(inner_ptr: *mut FaissIndex) -> Result<Self>
     where
         Self: Sized;
 }
@@ -476,7 +489,7 @@ impl FromInnerPtr for IndexImpl {
 }
 
 impl TryFromInnerPtr for IndexImpl {
-    fn try_from_inner_ptr(inner_ptr: *mut FaissIndex) -> Result<Self>
+    unsafe fn try_from_inner_ptr(inner_ptr: *mut FaissIndex) -> Result<Self>
     where
         Self: Sized,
     {


### PR DESCRIPTION
Although some checks are made in this function, they are not enough to ensure memory safety: passing a dangling pointer is UB because dynamic casts still require dereferencing the pointer.