### PR TITLE
fix: Use c_char instead of i8

### DIFF
--- a/src/index/ivf_flat.rs
+++ b/src/index/ivf_flat.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::error::Result;
 use crate::faiss_try;
 use std::mem;
-use std::os::raw::c_int;
+use std::os::raw::{c_int, c_char};
 use std::ptr;
 
 /// Alias for the native implementation of a flat index.
@@ -116,7 +116,7 @@ pub enum TrainType {
 }
 
 impl TrainType {
-    pub(crate) fn from_code(code: i8) -> Option<Self> {
+    pub(crate) fn from_code(code: c_char) -> Option<Self> {
         match code {
             0 => Some(TrainType::QuantizerAsIndex),
             1 => Some(TrainType::QuantizerTrainsAlone),


### PR DESCRIPTION
The following line is problematic as `std::os::raw::c_char` can either be `u8` or `i8` depending on the OS distribution.
I think it is possible to use `c_char` directly and avoid the issue.

What do you think?