### PR TITLE
Relax ConcurrentIndex trait bounds

### DIFF
--- a/src/index/id_map.rs
+++ b/src/index/id_map.rs
@@ -317,7 +317,7 @@ impl<I> Index for IdMap<I> {
 
 impl<I> ConcurrentIndex for IdMap<I>
 where
-    I: ConcurrentIndex,
+    I: Index,
 {
     fn assign(&self, query: &[f32], k: usize) -> Result<AssignSearchResult> {
         unsafe {

--- a/src/index/id_map.rs
+++ b/src/index/id_map.rs
@@ -317,7 +317,7 @@ impl<I> Index for IdMap<I> {
 
 impl<I> ConcurrentIndex for IdMap<I>
 where
-    I: Index,
+    I: Index + NativeIndex,
 {
     fn assign(&self, query: &[f32], k: usize) -> Result<AssignSearchResult> {
         unsafe {

--- a/src/index/pretransform.rs
+++ b/src/index/pretransform.rs
@@ -233,7 +233,7 @@ impl<I: TryClone> TryClone for PreTransformIndexImpl<I> {}
 
 impl<I> ConcurrentIndex for PreTransformIndexImpl<I>
 where
-    I: Index,
+    I: Index + NativeIndex,
 {
     fn assign(&self, query: &[f32], k: usize) -> Result<AssignSearchResult> {
         unsafe {

--- a/src/index/pretransform.rs
+++ b/src/index/pretransform.rs
@@ -233,7 +233,7 @@ impl<I: TryClone> TryClone for PreTransformIndexImpl<I> {}
 
 impl<I> ConcurrentIndex for PreTransformIndexImpl<I>
 where
-    I: ConcurrentIndex,
+    I: Index,
 {
     fn assign(&self, query: &[f32], k: usize) -> Result<AssignSearchResult> {
         unsafe {

--- a/src/index/refine_flat.rs
+++ b/src/index/refine_flat.rs
@@ -204,7 +204,7 @@ impl<BI: TryClone> TryClone for RefineFlatIndexImpl<BI> {}
 
 impl<BI> ConcurrentIndex for RefineFlatIndexImpl<BI>
 where
-    BI: Index,
+    BI: Index + NativeIndex,
 {
     fn assign(&self, query: &[f32], k: usize) -> Result<AssignSearchResult> {
         unsafe {

--- a/src/index/refine_flat.rs
+++ b/src/index/refine_flat.rs
@@ -204,7 +204,7 @@ impl<BI: TryClone> TryClone for RefineFlatIndexImpl<BI> {}
 
 impl<BI> ConcurrentIndex for RefineFlatIndexImpl<BI>
 where
-    BI: ConcurrentIndex,
+    BI: Index,
 {
     fn assign(&self, query: &[f32], k: usize) -> Result<AssignSearchResult> {
         unsafe {

--- a/src/index/scalar_quantizer.rs
+++ b/src/index/scalar_quantizer.rs
@@ -407,7 +407,7 @@ impl<Q: TryClone> TryClone for IVFScalarQuantizerIndexImpl<Q> {}
 
 impl<Q> ConcurrentIndex for IVFScalarQuantizerIndexImpl<Q>
 where
-    Q: ConcurrentIndex,
+    Q: Index,
 {
     fn assign(&self, query: &[f32], k: usize) -> Result<AssignSearchResult> {
         unsafe {

--- a/src/index/scalar_quantizer.rs
+++ b/src/index/scalar_quantizer.rs
@@ -407,7 +407,7 @@ impl<Q: TryClone> TryClone for IVFScalarQuantizerIndexImpl<Q> {}
 
 impl<Q> ConcurrentIndex for IVFScalarQuantizerIndexImpl<Q>
 where
-    Q: Index,
+    Q: Index + NativeIndex,
 {
     fn assign(&self, query: &[f32], k: usize) -> Result<AssignSearchResult> {
         unsafe {


### PR DESCRIPTION
Hello.

When we use composite indexes, we pass a pointer only to the main index through the C API. We should not be interested in how Fais works internally with the subindex.