### PR TITLE
Reorganize imports & Clippy-fix

### DIFF
--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -227,9 +227,9 @@ impl Clustering {
      * Perform the clustering algorithm with the given data and index.
      * The index is used during the assignment stage.
      */
-    pub fn train<I: ?Sized>(&mut self, x: &[f32], index: &mut I) -> Result<()>
+    pub fn train<I>(&mut self, x: &[f32], index: &mut I) -> Result<()>
     where
-        I: NativeIndex,
+        I: ?Sized + NativeIndex,
     {
         unsafe {
             let n = x.len() / self.d() as usize;

--- a/src/index/autotune.rs
+++ b/src/index/autotune.rs
@@ -63,7 +63,7 @@ impl Drop for ParameterSpace {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::index::autotune::ParameterSpace;
     use crate::index::index_factory;
     use crate::metric::MetricType;
 

--- a/src/index/autotune.rs
+++ b/src/index/autotune.rs
@@ -1,10 +1,6 @@
 use std::ffi;
-use std::ptr;
 
 use super::*;
-
-use crate::error::{Error, Result};
-use crate::faiss_try;
 
 /// Uses a-priori knowledge on the Faiss indexes to extract tunable parameters.
 pub struct ParameterSpace {

--- a/src/index/flat.rs
+++ b/src/index/flat.rs
@@ -2,11 +2,6 @@
 
 use super::*;
 
-use crate::error::{Error, Result};
-use crate::faiss_try;
-use std::mem;
-use std::ptr;
-
 /// Alias for the native implementation of a flat index.
 pub type FlatIndex = FlatIndexImpl;
 

--- a/src/index/ivf_flat.rs
+++ b/src/index/ivf_flat.rs
@@ -2,11 +2,7 @@
 
 use super::*;
 
-use crate::error::Result;
-use crate::faiss_try;
-use std::mem;
 use std::os::raw::{c_char, c_int};
-use std::ptr;
 
 /// Alias for the native implementation of a flat index.
 pub type IVFFlatIndex = IVFFlatIndexImpl;

--- a/src/index/pretransform.rs
+++ b/src/index/pretransform.rs
@@ -294,7 +294,8 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::index::pretransform::PreTransformIndexImpl;
+    use crate::index::UpcastIndex as _;
     use crate::metric::MetricType;
     use crate::{
         index::{index_factory, ConcurrentIndex, Idx, Index},

--- a/src/index/pretransform.rs
+++ b/src/index/pretransform.rs
@@ -2,13 +2,9 @@
 
 use super::*;
 
-use crate::error::{Error, Result};
-use crate::faiss_try;
 use crate::vector_transform::NativeVectorTransform;
 use std::marker::PhantomData;
-use std::mem;
 use std::os::raw::c_int;
-use std::ptr;
 
 /// Alias for the native implementation of a PreTransform index.
 pub type PreTransformIndex<I> = PreTransformIndexImpl<I>;

--- a/src/index/refine_flat.rs
+++ b/src/index/refine_flat.rs
@@ -2,12 +2,8 @@
 
 use super::*;
 
-use crate::error::Result;
-use crate::faiss_try;
 use std::marker::PhantomData;
-use std::mem;
 use std::os::raw::c_int;
-use std::ptr;
 
 /// Alias for the native implementation of a index.
 pub type RefineFlatIndex<BI> = RefineFlatIndexImpl<BI>;

--- a/src/index/scalar_quantizer.rs
+++ b/src/index/scalar_quantizer.rs
@@ -2,12 +2,8 @@
 
 use super::*;
 
-use crate::error::Result;
-use crate::faiss_try;
 use std::marker::PhantomData;
-use std::mem;
 use std::os::raw::c_int;
-use std::ptr;
 
 /// Alias for the native implementation of a scalar quantizer index.
 pub type ScalarQuantizerIndex = ScalarQuantizerIndexImpl;


### PR DESCRIPTION
- Reorganize imports
- Clippy lint fix: multiple_bound_locations
