### PR TITLE
Add support for working with binary indexes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master ]
+    branches: [ master, "change/faiss-v1.8.0" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ master ]
   pull_request:
-    branches: [ master, "change/faiss-v1.8.0" ]
+    branches: [ master ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/faiss-sys/src/bindings.rs
+++ b/faiss-sys/src/bindings.rs
@@ -297,14 +297,6 @@ extern "C" {
         arg3: *mut *mut FaissParameterRange,
     ) -> ::std::os::raw::c_int;
 }
-pub type FILE = [u64; 27usize];
-extern "C" {
-    #[doc = " Clone an index. This is equivalent to `faiss::clone_index`"]
-    pub fn faiss_clone_index(
-        arg1: *const FaissIndex,
-        p_out: *mut *mut FaissIndex,
-    ) -> ::std::os::raw::c_int;
-}
 #[doc = " Class for the clustering parameters. Can be passed to the\n constructor of the Clustering object."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -593,19 +585,309 @@ extern "C" {
         q_error: *mut f32,
     ) -> ::std::os::raw::c_int;
 }
-#[doc = " No error"]
-pub const FaissErrorCode_OK: FaissErrorCode = 0;
-#[doc = " Any exception other than Faiss or standard C++ library exceptions"]
-pub const FaissErrorCode_UNKNOWN_EXCEPT: FaissErrorCode = -1;
-#[doc = " Faiss library exception"]
-pub const FaissErrorCode_FAISS_EXCEPT: FaissErrorCode = -2;
-#[doc = " Standard C++ library exception"]
-pub const FaissErrorCode_STD_EXCEPT: FaissErrorCode = -4;
-#[doc = " An error code which depends on the exception thrown from the previous\n operation. See `faiss_get_last_error` to retrieve the error message."]
-pub type FaissErrorCode = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FaissIndexBinary_H {
+    _unused: [u8; 0],
+}
+pub type FaissIndexBinary = FaissIndexBinary_H;
 extern "C" {
-    #[doc = " Get the error message of the last failed operation performed by Faiss.\n The given pointer is only invalid until another Faiss function is\n called."]
-    pub fn faiss_get_last_error() -> *const ::std::os::raw::c_char;
+    pub fn faiss_IndexBinary_free(obj: *mut FaissIndexBinary);
+}
+extern "C" {
+    pub fn faiss_IndexBinary_d(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexBinary_is_trained(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexBinary_ntotal(arg1: *const FaissIndexBinary) -> idx_t;
+}
+extern "C" {
+    pub fn faiss_IndexBinary_metric_type(arg1: *const FaissIndexBinary) -> FaissMetricType;
+}
+extern "C" {
+    pub fn faiss_IndexBinary_verbose(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexBinary_set_verbose(arg1: *mut FaissIndexBinary, arg2: ::std::os::raw::c_int);
+}
+extern "C" {
+    #[doc = " Perform training on a representative set of vectors\n\n @param index  opaque pointer to index object\n @param n      nb of training vectors\n @param x      training vectors, size n * d"]
+    pub fn faiss_IndexBinary_train(
+        index: *mut FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Add n vectors of dimension d to the index.\n\n Vectors are implicitly assigned labels ntotal .. ntotal + n - 1\n This function slices the input vectors in chunks smaller than\n blocksize_add and calls add_core.\n @param index  opaque pointer to index object\n @param x      input matrix, size n * d"]
+    pub fn faiss_IndexBinary_add(
+        index: *mut FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Same as add, but stores xids instead of sequential ids.\n\n The default implementation fails with an assertion, as it is\n not supported by all indexes.\n\n @param index  opaque pointer to index object\n @param xids   if non-null, ids to store for the vectors (size n)"]
+    pub fn faiss_IndexBinary_add_with_ids(
+        index: *mut FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+        xids: *const idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " query n vectors of dimension d to the index.\n\n return at most k vectors. If there are not enough results for a\n query, the result array is padded with -1s.\n\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param labels      output labels of the NNs, size n*k\n @param distances   output pairwise distances, size n*k"]
+    pub fn faiss_IndexBinary_search(
+        index: *const FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+        k: idx_t,
+        distances: *mut i32,
+        labels: *mut idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " query n vectors of dimension d to the index.\n\n return all vectors with distance < radius. Note that many\n indexes do not implement the range_search (only the k-NN search\n is mandatory).\n\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param radius      search radius\n @param result      result table"]
+    pub fn faiss_IndexBinary_range_search(
+        index: *const FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+        radius: ::std::os::raw::c_int,
+        result: *mut FaissRangeSearchResult,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " return the indexes of the k vectors closest to the query x.\n\n This function is identical as search but only return labels of neighbors.\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param labels      output labels of the NNs, size n*k"]
+    pub fn faiss_IndexBinary_assign(
+        index: *mut FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+        labels: *mut idx_t,
+        k: idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " removes all elements from the database.\n @param index       opaque pointer to index object"]
+    pub fn faiss_IndexBinary_reset(index: *mut FaissIndexBinary) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " removes IDs from the index. Not supported by all indexes\n @param index       opaque pointer to index object\n @param nremove     output for the number of IDs removed"]
+    pub fn faiss_IndexBinary_remove_ids(
+        index: *mut FaissIndexBinary,
+        sel: *const FaissIDSelector,
+        n_removed: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Reconstruct a stored vector (or an approximation if lossy coding)\n\n this function may not be defined for some indexes\n @param index       opaque pointer to index object\n @param key         id of the vector to reconstruct\n @param recons      reconstructed vector (size d)"]
+    pub fn faiss_IndexBinary_reconstruct(
+        index: *const FaissIndexBinary,
+        key: idx_t,
+        recons: *mut u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Reconstruct vectors i0 to i0 + ni - 1\n\n this function may not be defined for some indexes\n @param index       opaque pointer to index object\n @param recons      reconstructed vector (size ni * d)"]
+    pub fn faiss_IndexBinary_reconstruct_n(
+        index: *const FaissIndexBinary,
+        i0: idx_t,
+        ni: idx_t,
+        recons: *mut u8,
+    ) -> ::std::os::raw::c_int;
+}
+pub type FaissIndexFlat = FaissIndex_H;
+extern "C" {
+    #[doc = " Opaque type for IndexFlat"]
+    pub fn faiss_IndexFlat_new(p_index: *mut *mut FaissIndexFlat) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexFlat_new_with(
+        p_index: *mut *mut FaissIndexFlat,
+        d: idx_t,
+        metric: FaissMetricType,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " get a pointer to the index's internal data (the `xb` field). The outputs\n become invalid after any data addition or removal operation.\n\n @param index   opaque pointer to index object\n @param p_xb    output, the pointer to the beginning of `xb`.\n @param p_size  output, the current size of `sb` in number of float values."]
+    pub fn faiss_IndexFlat_xb(index: *mut FaissIndexFlat, p_xb: *mut *mut f32, p_size: *mut usize);
+}
+extern "C" {
+    pub fn faiss_IndexFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlat;
+}
+extern "C" {
+    pub fn faiss_IndexFlat_free(obj: *mut FaissIndexFlat);
+}
+extern "C" {
+    #[doc = " compute distance with a subset of vectors\n\n @param index   opaque pointer to index object\n @param x       query vectors, size n * d\n @param labels  indices of the vectors that should be compared\n                for each query vector, size n * k\n @param distances\n                corresponding output distances, size n * k"]
+    pub fn faiss_IndexFlat_compute_distance_subset(
+        index: *mut FaissIndex,
+        n: idx_t,
+        x: *const f32,
+        k: idx_t,
+        distances: *mut f32,
+        labels: *const idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type FaissIndexFlatIP = FaissIndex_H;
+extern "C" {
+    pub fn faiss_IndexFlatIP_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlatIP;
+}
+extern "C" {
+    pub fn faiss_IndexFlatIP_free(obj: *mut FaissIndexFlatIP);
+}
+extern "C" {
+    #[doc = " Opaque type for IndexFlatIP"]
+    pub fn faiss_IndexFlatIP_new(p_index: *mut *mut FaissIndexFlatIP) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexFlatIP_new_with(
+        p_index: *mut *mut FaissIndexFlatIP,
+        d: idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type FaissIndexFlatL2 = FaissIndex_H;
+extern "C" {
+    pub fn faiss_IndexFlatL2_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlatL2;
+}
+extern "C" {
+    pub fn faiss_IndexFlatL2_free(obj: *mut FaissIndexFlatL2);
+}
+extern "C" {
+    #[doc = " Opaque type for IndexFlatL2"]
+    pub fn faiss_IndexFlatL2_new(p_index: *mut *mut FaissIndexFlatL2) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexFlatL2_new_with(
+        p_index: *mut *mut FaissIndexFlatL2,
+        d: idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type FaissIndexRefineFlat = FaissIndex_H;
+extern "C" {
+    #[doc = " Opaque type for IndexRefineFlat\n\n Index that queries in a base_index (a fast one) and refines the\n results with an exact search, hopefully improving the results."]
+    pub fn faiss_IndexRefineFlat_new(
+        p_index: *mut *mut FaissIndexRefineFlat,
+        base_index: *mut FaissIndex,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_free(obj: *mut FaissIndexRefineFlat);
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexRefineFlat;
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_own_fields(
+        arg1: *const FaissIndexRefineFlat,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_set_own_fields(
+        arg1: *mut FaissIndexRefineFlat,
+        arg2: ::std::os::raw::c_int,
+    );
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_k_factor(arg1: *const FaissIndexRefineFlat) -> f32;
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_set_k_factor(arg1: *mut FaissIndexRefineFlat, arg2: f32);
+}
+pub type FaissIndexFlat1D = FaissIndex_H;
+extern "C" {
+    pub fn faiss_IndexFlat1D_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlat1D;
+}
+extern "C" {
+    pub fn faiss_IndexFlat1D_free(obj: *mut FaissIndexFlat1D);
+}
+extern "C" {
+    #[doc = " Opaque type for IndexFlat1D\n\n optimized version for 1D \"vectors\""]
+    pub fn faiss_IndexFlat1D_new(p_index: *mut *mut FaissIndexFlat1D) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexFlat1D_new_with(
+        p_index: *mut *mut FaissIndexFlat1D,
+        continuous_update: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexFlat1D_update_permutation(
+        index: *mut FaissIndexFlat1D,
+    ) -> ::std::os::raw::c_int;
+}
+pub type FaissIndexIVFFlat = FaissIndex_H;
+extern "C" {
+    pub fn faiss_IndexIVFFlat_free(obj: *mut FaissIndexIVFFlat);
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexIVFFlat;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_nlist(arg1: *const FaissIndexIVFFlat) -> usize;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_nprobe(arg1: *const FaissIndexIVFFlat) -> usize;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_set_nprobe(arg1: *mut FaissIndexIVFFlat, arg2: usize);
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_quantizer(arg1: *const FaissIndexIVFFlat) -> *mut FaissIndex;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_quantizer_trains_alone(
+        arg1: *const FaissIndexIVFFlat,
+    ) -> ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_own_fields(arg1: *const FaissIndexIVFFlat) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_set_own_fields(
+        arg1: *mut FaissIndexIVFFlat,
+        arg2: ::std::os::raw::c_int,
+    );
+}
+extern "C" {
+    #[doc = " whether object owns the quantizer"]
+    pub fn faiss_IndexIVFFlat_new(p_index: *mut *mut FaissIndexIVFFlat) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_new_with(
+        p_index: *mut *mut FaissIndexIVFFlat,
+        quantizer: *mut FaissIndex,
+        d: usize,
+        nlist: usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_new_with_metric(
+        p_index: *mut *mut FaissIndexIVFFlat,
+        quantizer: *mut FaissIndex,
+        d: usize,
+        nlist: usize,
+        metric: FaissMetricType,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_add_core(
+        index: *mut FaissIndexIVFFlat,
+        n: idx_t,
+        x: *const f32,
+        xids: *const idx_t,
+        precomputed_idx: *const i64,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Update a subset of vectors.\n\n The index must have a direct_map\n\n @param nv     nb of vectors to update\n @param idx    vector indices to update, size nv\n @param v      vectors of new values, size nv*d"]
+    pub fn faiss_IndexIVFFlat_update_vectors(
+        index: *mut FaissIndexIVFFlat,
+        nv: ::std::os::raw::c_int,
+        idx: *mut idx_t,
+        v: *const f32,
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn faiss_RangeSearchResult_nq(arg1: *const FaissRangeSearchResult) -> usize;
@@ -927,304 +1209,6 @@ extern "C" {
 extern "C" {
     pub fn faiss_DistanceComputer_free(obj: *mut FaissDistanceComputer);
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct FaissIndexBinary_H {
-    _unused: [u8; 0],
-}
-pub type FaissIndexBinary = FaissIndexBinary_H;
-extern "C" {
-    pub fn faiss_IndexBinary_free(obj: *mut FaissIndexBinary);
-}
-extern "C" {
-    pub fn faiss_IndexBinary_d(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexBinary_is_trained(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexBinary_ntotal(arg1: *const FaissIndexBinary) -> idx_t;
-}
-extern "C" {
-    pub fn faiss_IndexBinary_metric_type(arg1: *const FaissIndexBinary) -> FaissMetricType;
-}
-extern "C" {
-    pub fn faiss_IndexBinary_verbose(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexBinary_set_verbose(arg1: *mut FaissIndexBinary, arg2: ::std::os::raw::c_int);
-}
-extern "C" {
-    #[doc = " Perform training on a representative set of vectors\n\n @param index  opaque pointer to index object\n @param n      nb of training vectors\n @param x      training vectors, size n * d"]
-    pub fn faiss_IndexBinary_train(
-        index: *mut FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Add n vectors of dimension d to the index.\n\n Vectors are implicitly assigned labels ntotal .. ntotal + n - 1\n This function slices the input vectors in chunks smaller than\n blocksize_add and calls add_core.\n @param index  opaque pointer to index object\n @param x      input matrix, size n * d"]
-    pub fn faiss_IndexBinary_add(
-        index: *mut FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Same as add, but stores xids instead of sequential ids.\n\n The default implementation fails with an assertion, as it is\n not supported by all indexes.\n\n @param index  opaque pointer to index object\n @param xids   if non-null, ids to store for the vectors (size n)"]
-    pub fn faiss_IndexBinary_add_with_ids(
-        index: *mut FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-        xids: *const idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " query n vectors of dimension d to the index.\n\n return at most k vectors. If there are not enough results for a\n query, the result array is padded with -1s.\n\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param labels      output labels of the NNs, size n*k\n @param distances   output pairwise distances, size n*k"]
-    pub fn faiss_IndexBinary_search(
-        index: *const FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-        k: idx_t,
-        distances: *mut i32,
-        labels: *mut idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " query n vectors of dimension d to the index.\n\n return all vectors with distance < radius. Note that many\n indexes do not implement the range_search (only the k-NN search\n is mandatory).\n\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param radius      search radius\n @param result      result table"]
-    pub fn faiss_IndexBinary_range_search(
-        index: *const FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-        radius: ::std::os::raw::c_int,
-        result: *mut FaissRangeSearchResult,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " return the indexes of the k vectors closest to the query x.\n\n This function is identical as search but only return labels of neighbors.\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param labels      output labels of the NNs, size n*k"]
-    pub fn faiss_IndexBinary_assign(
-        index: *mut FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-        labels: *mut idx_t,
-        k: idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " removes all elements from the database.\n @param index       opaque pointer to index object"]
-    pub fn faiss_IndexBinary_reset(index: *mut FaissIndexBinary) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " removes IDs from the index. Not supported by all indexes\n @param index       opaque pointer to index object\n @param nremove     output for the number of IDs removed"]
-    pub fn faiss_IndexBinary_remove_ids(
-        index: *mut FaissIndexBinary,
-        sel: *const FaissIDSelector,
-        n_removed: *mut usize,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Reconstruct a stored vector (or an approximation if lossy coding)\n\n this function may not be defined for some indexes\n @param index       opaque pointer to index object\n @param key         id of the vector to reconstruct\n @param recons      reconstructed vector (size d)"]
-    pub fn faiss_IndexBinary_reconstruct(
-        index: *const FaissIndexBinary,
-        key: idx_t,
-        recons: *mut u8,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Reconstruct vectors i0 to i0 + ni - 1\n\n this function may not be defined for some indexes\n @param index       opaque pointer to index object\n @param recons      reconstructed vector (size ni * d)"]
-    pub fn faiss_IndexBinary_reconstruct_n(
-        index: *const FaissIndexBinary,
-        i0: idx_t,
-        ni: idx_t,
-        recons: *mut u8,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Build and index with the sequence of processing steps described in\n  the string."]
-    pub fn faiss_index_factory(
-        p_index: *mut *mut FaissIndex,
-        d: ::std::os::raw::c_int,
-        description: *const ::std::os::raw::c_char,
-        metric: FaissMetricType,
-    ) -> ::std::os::raw::c_int;
-}
-pub type FaissIndexFlat = FaissIndex_H;
-extern "C" {
-    #[doc = " Opaque type for IndexFlat"]
-    pub fn faiss_IndexFlat_new(p_index: *mut *mut FaissIndexFlat) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexFlat_new_with(
-        p_index: *mut *mut FaissIndexFlat,
-        d: idx_t,
-        metric: FaissMetricType,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " get a pointer to the index's internal data (the `xb` field). The outputs\n become invalid after any data addition or removal operation.\n\n @param index   opaque pointer to index object\n @param p_xb    output, the pointer to the beginning of `xb`.\n @param p_size  output, the current size of `sb` in number of float values."]
-    pub fn faiss_IndexFlat_xb(index: *mut FaissIndexFlat, p_xb: *mut *mut f32, p_size: *mut usize);
-}
-extern "C" {
-    pub fn faiss_IndexFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlat;
-}
-extern "C" {
-    pub fn faiss_IndexFlat_free(obj: *mut FaissIndexFlat);
-}
-extern "C" {
-    #[doc = " compute distance with a subset of vectors\n\n @param index   opaque pointer to index object\n @param x       query vectors, size n * d\n @param labels  indices of the vectors that should be compared\n                for each query vector, size n * k\n @param distances\n                corresponding output distances, size n * k"]
-    pub fn faiss_IndexFlat_compute_distance_subset(
-        index: *mut FaissIndex,
-        n: idx_t,
-        x: *const f32,
-        k: idx_t,
-        distances: *mut f32,
-        labels: *const idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-pub type FaissIndexFlatIP = FaissIndex_H;
-extern "C" {
-    pub fn faiss_IndexFlatIP_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlatIP;
-}
-extern "C" {
-    pub fn faiss_IndexFlatIP_free(obj: *mut FaissIndexFlatIP);
-}
-extern "C" {
-    #[doc = " Opaque type for IndexFlatIP"]
-    pub fn faiss_IndexFlatIP_new(p_index: *mut *mut FaissIndexFlatIP) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexFlatIP_new_with(
-        p_index: *mut *mut FaissIndexFlatIP,
-        d: idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-pub type FaissIndexFlatL2 = FaissIndex_H;
-extern "C" {
-    pub fn faiss_IndexFlatL2_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlatL2;
-}
-extern "C" {
-    pub fn faiss_IndexFlatL2_free(obj: *mut FaissIndexFlatL2);
-}
-extern "C" {
-    #[doc = " Opaque type for IndexFlatL2"]
-    pub fn faiss_IndexFlatL2_new(p_index: *mut *mut FaissIndexFlatL2) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexFlatL2_new_with(
-        p_index: *mut *mut FaissIndexFlatL2,
-        d: idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-pub type FaissIndexRefineFlat = FaissIndex_H;
-extern "C" {
-    #[doc = " Opaque type for IndexRefineFlat\n\n Index that queries in a base_index (a fast one) and refines the\n results with an exact search, hopefully improving the results."]
-    pub fn faiss_IndexRefineFlat_new(
-        p_index: *mut *mut FaissIndexRefineFlat,
-        base_index: *mut FaissIndex,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_free(obj: *mut FaissIndexRefineFlat);
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexRefineFlat;
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_own_fields(
-        arg1: *const FaissIndexRefineFlat,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_set_own_fields(
-        arg1: *mut FaissIndexRefineFlat,
-        arg2: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_k_factor(arg1: *const FaissIndexRefineFlat) -> f32;
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_set_k_factor(arg1: *mut FaissIndexRefineFlat, arg2: f32);
-}
-pub type FaissIndexFlat1D = FaissIndex_H;
-extern "C" {
-    pub fn faiss_IndexFlat1D_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlat1D;
-}
-extern "C" {
-    pub fn faiss_IndexFlat1D_free(obj: *mut FaissIndexFlat1D);
-}
-extern "C" {
-    #[doc = " Opaque type for IndexFlat1D\n\n optimized version for 1D \"vectors\""]
-    pub fn faiss_IndexFlat1D_new(p_index: *mut *mut FaissIndexFlat1D) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexFlat1D_new_with(
-        p_index: *mut *mut FaissIndexFlat1D,
-        continuous_update: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexFlat1D_update_permutation(
-        index: *mut FaissIndexFlat1D,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index` when a file descriptor is\n provided."]
-    pub fn faiss_write_index(idx: *const FaissIndex, f: *mut FILE) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index` when a file path is provided."]
-    pub fn faiss_write_index_fname(
-        idx: *const FaissIndex,
-        fname: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index` when a file descriptor is given."]
-    pub fn faiss_read_index(
-        f: *mut FILE,
-        io_flags: ::std::os::raw::c_int,
-        p_out: *mut *mut FaissIndex,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index` when a file path is given."]
-    pub fn faiss_read_index_fname(
-        fname: *const ::std::os::raw::c_char,
-        io_flags: ::std::os::raw::c_int,
-        p_out: *mut *mut FaissIndex,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index_binary` when a file descriptor is\n provided."]
-    pub fn faiss_write_index_binary(
-        idx: *const FaissIndexBinary,
-        f: *mut FILE,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index_binary` when a file path is\n provided."]
-    pub fn faiss_write_index_binary_fname(
-        idx: *const FaissIndexBinary,
-        fname: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index_binary` when a file descriptor is\n given."]
-    pub fn faiss_read_index_binary(
-        f: *mut FILE,
-        io_flags: ::std::os::raw::c_int,
-        p_out: *mut *mut FaissIndexBinary,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index_binary` when a file path is given."]
-    pub fn faiss_read_index_binary_fname(
-        fname: *const ::std::os::raw::c_char,
-        io_flags: ::std::os::raw::c_int,
-        p_out: *mut *mut FaissIndexBinary,
-    ) -> ::std::os::raw::c_int;
-}
 pub type FaissSearchParametersIVF = FaissSearchParameters_H;
 extern "C" {
     pub fn faiss_SearchParametersIVF_free(obj: *mut FaissSearchParametersIVF);
@@ -1454,78 +1438,6 @@ extern "C" {
 extern "C" {
     #[doc = " global var that collects all statists"]
     pub fn faiss_get_indexIVF_stats() -> *mut FaissIndexIVFStats;
-}
-pub type FaissIndexIVFFlat = FaissIndex_H;
-extern "C" {
-    pub fn faiss_IndexIVFFlat_free(obj: *mut FaissIndexIVFFlat);
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexIVFFlat;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_nlist(arg1: *const FaissIndexIVFFlat) -> usize;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_nprobe(arg1: *const FaissIndexIVFFlat) -> usize;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_set_nprobe(arg1: *mut FaissIndexIVFFlat, arg2: usize);
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_quantizer(arg1: *const FaissIndexIVFFlat) -> *mut FaissIndex;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_quantizer_trains_alone(
-        arg1: *const FaissIndexIVFFlat,
-    ) -> ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_own_fields(arg1: *const FaissIndexIVFFlat) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_set_own_fields(
-        arg1: *mut FaissIndexIVFFlat,
-        arg2: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    #[doc = " whether object owns the quantizer"]
-    pub fn faiss_IndexIVFFlat_new(p_index: *mut *mut FaissIndexIVFFlat) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_new_with(
-        p_index: *mut *mut FaissIndexIVFFlat,
-        quantizer: *mut FaissIndex,
-        d: usize,
-        nlist: usize,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_new_with_metric(
-        p_index: *mut *mut FaissIndexIVFFlat,
-        quantizer: *mut FaissIndex,
-        d: usize,
-        nlist: usize,
-        metric: FaissMetricType,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_add_core(
-        index: *mut FaissIndexIVFFlat,
-        n: idx_t,
-        x: *const f32,
-        xids: *const idx_t,
-        precomputed_idx: *const i64,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Update a subset of vectors.\n\n The index must have a direct_map\n\n @param nv     nb of vectors to update\n @param idx    vector indices to update, size nv\n @param v      vectors of new values, size nv*d"]
-    pub fn faiss_IndexIVFFlat_update_vectors(
-        index: *mut FaissIndexIVFFlat,
-        nv: ::std::os::raw::c_int,
-        idx: *mut idx_t,
-        v: *const f32,
-    ) -> ::std::os::raw::c_int;
 }
 pub type FaissIndexLSH = FaissIndex_H;
 extern "C" {
@@ -2091,6 +2003,109 @@ extern "C" {
 extern "C" {
     #[doc = " get a pointer to the sub-index (the `index` field).\n The outputs of this function become invalid after any operation that can\n modify the index.\n\n @param index   opaque pointer to index object"]
     pub fn faiss_IndexIDMap2_sub_index(index: *mut FaissIndexIDMap2) -> *mut FaissIndex;
+}
+pub type FILE = [u64; 27usize];
+extern "C" {
+    #[doc = " Clone an index. This is equivalent to `faiss::clone_index`"]
+    pub fn faiss_clone_index(
+        arg1: *const FaissIndex,
+        p_out: *mut *mut FaissIndex,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Clone a binary index. This is equivalent to `faiss::clone_index_binary`"]
+    pub fn faiss_clone_index_binary(
+        arg1: *const FaissIndexBinary,
+        p_out: *mut *mut FaissIndexBinary,
+    ) -> ::std::os::raw::c_int;
+}
+#[doc = " No error"]
+pub const FaissErrorCode_OK: FaissErrorCode = 0;
+#[doc = " Any exception other than Faiss or standard C++ library exceptions"]
+pub const FaissErrorCode_UNKNOWN_EXCEPT: FaissErrorCode = -1;
+#[doc = " Faiss library exception"]
+pub const FaissErrorCode_FAISS_EXCEPT: FaissErrorCode = -2;
+#[doc = " Standard C++ library exception"]
+pub const FaissErrorCode_STD_EXCEPT: FaissErrorCode = -4;
+#[doc = " An error code which depends on the exception thrown from the previous\n operation. See `faiss_get_last_error` to retrieve the error message."]
+pub type FaissErrorCode = ::std::os::raw::c_int;
+extern "C" {
+    #[doc = " Get the error message of the last failed operation performed by Faiss.\n The given pointer is only invalid until another Faiss function is\n called."]
+    pub fn faiss_get_last_error() -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    #[doc = " Build an index with the sequence of processing steps described in\n  the string."]
+    pub fn faiss_index_factory(
+        p_index: *mut *mut FaissIndex,
+        d: ::std::os::raw::c_int,
+        description: *const ::std::os::raw::c_char,
+        metric: FaissMetricType,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Build a binary index with the sequence of processing steps described in\n  the string."]
+    pub fn faiss_index_binary_factory(
+        p_index: *mut *mut FaissIndexBinary,
+        d: ::std::os::raw::c_int,
+        description: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index` when a file descriptor is\n provided."]
+    pub fn faiss_write_index(idx: *const FaissIndex, f: *mut FILE) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index` when a file path is provided."]
+    pub fn faiss_write_index_fname(
+        idx: *const FaissIndex,
+        fname: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index` when a file descriptor is given."]
+    pub fn faiss_read_index(
+        f: *mut FILE,
+        io_flags: ::std::os::raw::c_int,
+        p_out: *mut *mut FaissIndex,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index` when a file path is given."]
+    pub fn faiss_read_index_fname(
+        fname: *const ::std::os::raw::c_char,
+        io_flags: ::std::os::raw::c_int,
+        p_out: *mut *mut FaissIndex,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index_binary` when a file descriptor is\n provided."]
+    pub fn faiss_write_index_binary(
+        idx: *const FaissIndexBinary,
+        f: *mut FILE,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index_binary` when a file path is\n provided."]
+    pub fn faiss_write_index_binary_fname(
+        idx: *const FaissIndexBinary,
+        fname: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index_binary` when a file descriptor is\n given."]
+    pub fn faiss_read_index_binary(
+        f: *mut FILE,
+        io_flags: ::std::os::raw::c_int,
+        p_out: *mut *mut FaissIndexBinary,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index_binary` when a file path is given."]
+    pub fn faiss_read_index_binary_fname(
+        fname: *const ::std::os::raw::c_char,
+        io_flags: ::std::os::raw::c_int,
+        p_out: *mut *mut FaissIndexBinary,
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     #[doc = " Compute pairwise distances between sets of vectors"]

--- a/faiss-sys/src/bindings_gpu.rs
+++ b/faiss-sys/src/bindings_gpu.rs
@@ -297,14 +297,6 @@ extern "C" {
         arg3: *mut *mut FaissParameterRange,
     ) -> ::std::os::raw::c_int;
 }
-pub type FILE = [u64; 27usize];
-extern "C" {
-    #[doc = " Clone an index. This is equivalent to `faiss::clone_index`"]
-    pub fn faiss_clone_index(
-        arg1: *const FaissIndex,
-        p_out: *mut *mut FaissIndex,
-    ) -> ::std::os::raw::c_int;
-}
 #[doc = " Class for the clustering parameters. Can be passed to the\n constructor of the Clustering object."]
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
@@ -593,19 +585,309 @@ extern "C" {
         q_error: *mut f32,
     ) -> ::std::os::raw::c_int;
 }
-#[doc = " No error"]
-pub const FaissErrorCode_OK: FaissErrorCode = 0;
-#[doc = " Any exception other than Faiss or standard C++ library exceptions"]
-pub const FaissErrorCode_UNKNOWN_EXCEPT: FaissErrorCode = -1;
-#[doc = " Faiss library exception"]
-pub const FaissErrorCode_FAISS_EXCEPT: FaissErrorCode = -2;
-#[doc = " Standard C++ library exception"]
-pub const FaissErrorCode_STD_EXCEPT: FaissErrorCode = -4;
-#[doc = " An error code which depends on the exception thrown from the previous\n operation. See `faiss_get_last_error` to retrieve the error message."]
-pub type FaissErrorCode = ::std::os::raw::c_int;
+#[repr(C)]
+#[derive(Debug, Copy, Clone)]
+pub struct FaissIndexBinary_H {
+    _unused: [u8; 0],
+}
+pub type FaissIndexBinary = FaissIndexBinary_H;
 extern "C" {
-    #[doc = " Get the error message of the last failed operation performed by Faiss.\n The given pointer is only invalid until another Faiss function is\n called."]
-    pub fn faiss_get_last_error() -> *const ::std::os::raw::c_char;
+    pub fn faiss_IndexBinary_free(obj: *mut FaissIndexBinary);
+}
+extern "C" {
+    pub fn faiss_IndexBinary_d(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexBinary_is_trained(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexBinary_ntotal(arg1: *const FaissIndexBinary) -> idx_t;
+}
+extern "C" {
+    pub fn faiss_IndexBinary_metric_type(arg1: *const FaissIndexBinary) -> FaissMetricType;
+}
+extern "C" {
+    pub fn faiss_IndexBinary_verbose(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexBinary_set_verbose(arg1: *mut FaissIndexBinary, arg2: ::std::os::raw::c_int);
+}
+extern "C" {
+    #[doc = " Perform training on a representative set of vectors\n\n @param index  opaque pointer to index object\n @param n      nb of training vectors\n @param x      training vectors, size n * d"]
+    pub fn faiss_IndexBinary_train(
+        index: *mut FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Add n vectors of dimension d to the index.\n\n Vectors are implicitly assigned labels ntotal .. ntotal + n - 1\n This function slices the input vectors in chunks smaller than\n blocksize_add and calls add_core.\n @param index  opaque pointer to index object\n @param x      input matrix, size n * d"]
+    pub fn faiss_IndexBinary_add(
+        index: *mut FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Same as add, but stores xids instead of sequential ids.\n\n The default implementation fails with an assertion, as it is\n not supported by all indexes.\n\n @param index  opaque pointer to index object\n @param xids   if non-null, ids to store for the vectors (size n)"]
+    pub fn faiss_IndexBinary_add_with_ids(
+        index: *mut FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+        xids: *const idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " query n vectors of dimension d to the index.\n\n return at most k vectors. If there are not enough results for a\n query, the result array is padded with -1s.\n\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param labels      output labels of the NNs, size n*k\n @param distances   output pairwise distances, size n*k"]
+    pub fn faiss_IndexBinary_search(
+        index: *const FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+        k: idx_t,
+        distances: *mut i32,
+        labels: *mut idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " query n vectors of dimension d to the index.\n\n return all vectors with distance < radius. Note that many\n indexes do not implement the range_search (only the k-NN search\n is mandatory).\n\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param radius      search radius\n @param result      result table"]
+    pub fn faiss_IndexBinary_range_search(
+        index: *const FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+        radius: ::std::os::raw::c_int,
+        result: *mut FaissRangeSearchResult,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " return the indexes of the k vectors closest to the query x.\n\n This function is identical as search but only return labels of neighbors.\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param labels      output labels of the NNs, size n*k"]
+    pub fn faiss_IndexBinary_assign(
+        index: *mut FaissIndexBinary,
+        n: idx_t,
+        x: *const u8,
+        labels: *mut idx_t,
+        k: idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " removes all elements from the database.\n @param index       opaque pointer to index object"]
+    pub fn faiss_IndexBinary_reset(index: *mut FaissIndexBinary) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " removes IDs from the index. Not supported by all indexes\n @param index       opaque pointer to index object\n @param nremove     output for the number of IDs removed"]
+    pub fn faiss_IndexBinary_remove_ids(
+        index: *mut FaissIndexBinary,
+        sel: *const FaissIDSelector,
+        n_removed: *mut usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Reconstruct a stored vector (or an approximation if lossy coding)\n\n this function may not be defined for some indexes\n @param index       opaque pointer to index object\n @param key         id of the vector to reconstruct\n @param recons      reconstructed vector (size d)"]
+    pub fn faiss_IndexBinary_reconstruct(
+        index: *const FaissIndexBinary,
+        key: idx_t,
+        recons: *mut u8,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Reconstruct vectors i0 to i0 + ni - 1\n\n this function may not be defined for some indexes\n @param index       opaque pointer to index object\n @param recons      reconstructed vector (size ni * d)"]
+    pub fn faiss_IndexBinary_reconstruct_n(
+        index: *const FaissIndexBinary,
+        i0: idx_t,
+        ni: idx_t,
+        recons: *mut u8,
+    ) -> ::std::os::raw::c_int;
+}
+pub type FaissIndexFlat = FaissIndex_H;
+extern "C" {
+    #[doc = " Opaque type for IndexFlat"]
+    pub fn faiss_IndexFlat_new(p_index: *mut *mut FaissIndexFlat) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexFlat_new_with(
+        p_index: *mut *mut FaissIndexFlat,
+        d: idx_t,
+        metric: FaissMetricType,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " get a pointer to the index's internal data (the `xb` field). The outputs\n become invalid after any data addition or removal operation.\n\n @param index   opaque pointer to index object\n @param p_xb    output, the pointer to the beginning of `xb`.\n @param p_size  output, the current size of `sb` in number of float values."]
+    pub fn faiss_IndexFlat_xb(index: *mut FaissIndexFlat, p_xb: *mut *mut f32, p_size: *mut usize);
+}
+extern "C" {
+    pub fn faiss_IndexFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlat;
+}
+extern "C" {
+    pub fn faiss_IndexFlat_free(obj: *mut FaissIndexFlat);
+}
+extern "C" {
+    #[doc = " compute distance with a subset of vectors\n\n @param index   opaque pointer to index object\n @param x       query vectors, size n * d\n @param labels  indices of the vectors that should be compared\n                for each query vector, size n * k\n @param distances\n                corresponding output distances, size n * k"]
+    pub fn faiss_IndexFlat_compute_distance_subset(
+        index: *mut FaissIndex,
+        n: idx_t,
+        x: *const f32,
+        k: idx_t,
+        distances: *mut f32,
+        labels: *const idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type FaissIndexFlatIP = FaissIndex_H;
+extern "C" {
+    pub fn faiss_IndexFlatIP_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlatIP;
+}
+extern "C" {
+    pub fn faiss_IndexFlatIP_free(obj: *mut FaissIndexFlatIP);
+}
+extern "C" {
+    #[doc = " Opaque type for IndexFlatIP"]
+    pub fn faiss_IndexFlatIP_new(p_index: *mut *mut FaissIndexFlatIP) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexFlatIP_new_with(
+        p_index: *mut *mut FaissIndexFlatIP,
+        d: idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type FaissIndexFlatL2 = FaissIndex_H;
+extern "C" {
+    pub fn faiss_IndexFlatL2_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlatL2;
+}
+extern "C" {
+    pub fn faiss_IndexFlatL2_free(obj: *mut FaissIndexFlatL2);
+}
+extern "C" {
+    #[doc = " Opaque type for IndexFlatL2"]
+    pub fn faiss_IndexFlatL2_new(p_index: *mut *mut FaissIndexFlatL2) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexFlatL2_new_with(
+        p_index: *mut *mut FaissIndexFlatL2,
+        d: idx_t,
+    ) -> ::std::os::raw::c_int;
+}
+pub type FaissIndexRefineFlat = FaissIndex_H;
+extern "C" {
+    #[doc = " Opaque type for IndexRefineFlat\n\n Index that queries in a base_index (a fast one) and refines the\n results with an exact search, hopefully improving the results."]
+    pub fn faiss_IndexRefineFlat_new(
+        p_index: *mut *mut FaissIndexRefineFlat,
+        base_index: *mut FaissIndex,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_free(obj: *mut FaissIndexRefineFlat);
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexRefineFlat;
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_own_fields(
+        arg1: *const FaissIndexRefineFlat,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_set_own_fields(
+        arg1: *mut FaissIndexRefineFlat,
+        arg2: ::std::os::raw::c_int,
+    );
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_k_factor(arg1: *const FaissIndexRefineFlat) -> f32;
+}
+extern "C" {
+    pub fn faiss_IndexRefineFlat_set_k_factor(arg1: *mut FaissIndexRefineFlat, arg2: f32);
+}
+pub type FaissIndexFlat1D = FaissIndex_H;
+extern "C" {
+    pub fn faiss_IndexFlat1D_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlat1D;
+}
+extern "C" {
+    pub fn faiss_IndexFlat1D_free(obj: *mut FaissIndexFlat1D);
+}
+extern "C" {
+    #[doc = " Opaque type for IndexFlat1D\n\n optimized version for 1D \"vectors\""]
+    pub fn faiss_IndexFlat1D_new(p_index: *mut *mut FaissIndexFlat1D) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexFlat1D_new_with(
+        p_index: *mut *mut FaissIndexFlat1D,
+        continuous_update: ::std::os::raw::c_int,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexFlat1D_update_permutation(
+        index: *mut FaissIndexFlat1D,
+    ) -> ::std::os::raw::c_int;
+}
+pub type FaissIndexIVFFlat = FaissIndex_H;
+extern "C" {
+    pub fn faiss_IndexIVFFlat_free(obj: *mut FaissIndexIVFFlat);
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexIVFFlat;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_nlist(arg1: *const FaissIndexIVFFlat) -> usize;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_nprobe(arg1: *const FaissIndexIVFFlat) -> usize;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_set_nprobe(arg1: *mut FaissIndexIVFFlat, arg2: usize);
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_quantizer(arg1: *const FaissIndexIVFFlat) -> *mut FaissIndex;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_quantizer_trains_alone(
+        arg1: *const FaissIndexIVFFlat,
+    ) -> ::std::os::raw::c_char;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_own_fields(arg1: *const FaissIndexIVFFlat) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_set_own_fields(
+        arg1: *mut FaissIndexIVFFlat,
+        arg2: ::std::os::raw::c_int,
+    );
+}
+extern "C" {
+    #[doc = " whether object owns the quantizer"]
+    pub fn faiss_IndexIVFFlat_new(p_index: *mut *mut FaissIndexIVFFlat) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_new_with(
+        p_index: *mut *mut FaissIndexIVFFlat,
+        quantizer: *mut FaissIndex,
+        d: usize,
+        nlist: usize,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_new_with_metric(
+        p_index: *mut *mut FaissIndexIVFFlat,
+        quantizer: *mut FaissIndex,
+        d: usize,
+        nlist: usize,
+        metric: FaissMetricType,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    pub fn faiss_IndexIVFFlat_add_core(
+        index: *mut FaissIndexIVFFlat,
+        n: idx_t,
+        x: *const f32,
+        xids: *const idx_t,
+        precomputed_idx: *const i64,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Update a subset of vectors.\n\n The index must have a direct_map\n\n @param nv     nb of vectors to update\n @param idx    vector indices to update, size nv\n @param v      vectors of new values, size nv*d"]
+    pub fn faiss_IndexIVFFlat_update_vectors(
+        index: *mut FaissIndexIVFFlat,
+        nv: ::std::os::raw::c_int,
+        idx: *mut idx_t,
+        v: *const f32,
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     pub fn faiss_RangeSearchResult_nq(arg1: *const FaissRangeSearchResult) -> usize;
@@ -927,304 +1209,6 @@ extern "C" {
 extern "C" {
     pub fn faiss_DistanceComputer_free(obj: *mut FaissDistanceComputer);
 }
-#[repr(C)]
-#[derive(Debug, Copy, Clone)]
-pub struct FaissIndexBinary_H {
-    _unused: [u8; 0],
-}
-pub type FaissIndexBinary = FaissIndexBinary_H;
-extern "C" {
-    pub fn faiss_IndexBinary_free(obj: *mut FaissIndexBinary);
-}
-extern "C" {
-    pub fn faiss_IndexBinary_d(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexBinary_is_trained(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexBinary_ntotal(arg1: *const FaissIndexBinary) -> idx_t;
-}
-extern "C" {
-    pub fn faiss_IndexBinary_metric_type(arg1: *const FaissIndexBinary) -> FaissMetricType;
-}
-extern "C" {
-    pub fn faiss_IndexBinary_verbose(arg1: *const FaissIndexBinary) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexBinary_set_verbose(arg1: *mut FaissIndexBinary, arg2: ::std::os::raw::c_int);
-}
-extern "C" {
-    #[doc = " Perform training on a representative set of vectors\n\n @param index  opaque pointer to index object\n @param n      nb of training vectors\n @param x      training vectors, size n * d"]
-    pub fn faiss_IndexBinary_train(
-        index: *mut FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Add n vectors of dimension d to the index.\n\n Vectors are implicitly assigned labels ntotal .. ntotal + n - 1\n This function slices the input vectors in chunks smaller than\n blocksize_add and calls add_core.\n @param index  opaque pointer to index object\n @param x      input matrix, size n * d"]
-    pub fn faiss_IndexBinary_add(
-        index: *mut FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Same as add, but stores xids instead of sequential ids.\n\n The default implementation fails with an assertion, as it is\n not supported by all indexes.\n\n @param index  opaque pointer to index object\n @param xids   if non-null, ids to store for the vectors (size n)"]
-    pub fn faiss_IndexBinary_add_with_ids(
-        index: *mut FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-        xids: *const idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " query n vectors of dimension d to the index.\n\n return at most k vectors. If there are not enough results for a\n query, the result array is padded with -1s.\n\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param labels      output labels of the NNs, size n*k\n @param distances   output pairwise distances, size n*k"]
-    pub fn faiss_IndexBinary_search(
-        index: *const FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-        k: idx_t,
-        distances: *mut i32,
-        labels: *mut idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " query n vectors of dimension d to the index.\n\n return all vectors with distance < radius. Note that many\n indexes do not implement the range_search (only the k-NN search\n is mandatory).\n\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param radius      search radius\n @param result      result table"]
-    pub fn faiss_IndexBinary_range_search(
-        index: *const FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-        radius: ::std::os::raw::c_int,
-        result: *mut FaissRangeSearchResult,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " return the indexes of the k vectors closest to the query x.\n\n This function is identical as search but only return labels of neighbors.\n @param index       opaque pointer to index object\n @param x           input vectors to search, size n * d\n @param labels      output labels of the NNs, size n*k"]
-    pub fn faiss_IndexBinary_assign(
-        index: *mut FaissIndexBinary,
-        n: idx_t,
-        x: *const u8,
-        labels: *mut idx_t,
-        k: idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " removes all elements from the database.\n @param index       opaque pointer to index object"]
-    pub fn faiss_IndexBinary_reset(index: *mut FaissIndexBinary) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " removes IDs from the index. Not supported by all indexes\n @param index       opaque pointer to index object\n @param nremove     output for the number of IDs removed"]
-    pub fn faiss_IndexBinary_remove_ids(
-        index: *mut FaissIndexBinary,
-        sel: *const FaissIDSelector,
-        n_removed: *mut usize,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Reconstruct a stored vector (or an approximation if lossy coding)\n\n this function may not be defined for some indexes\n @param index       opaque pointer to index object\n @param key         id of the vector to reconstruct\n @param recons      reconstructed vector (size d)"]
-    pub fn faiss_IndexBinary_reconstruct(
-        index: *const FaissIndexBinary,
-        key: idx_t,
-        recons: *mut u8,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Reconstruct vectors i0 to i0 + ni - 1\n\n this function may not be defined for some indexes\n @param index       opaque pointer to index object\n @param recons      reconstructed vector (size ni * d)"]
-    pub fn faiss_IndexBinary_reconstruct_n(
-        index: *const FaissIndexBinary,
-        i0: idx_t,
-        ni: idx_t,
-        recons: *mut u8,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Build and index with the sequence of processing steps described in\n  the string."]
-    pub fn faiss_index_factory(
-        p_index: *mut *mut FaissIndex,
-        d: ::std::os::raw::c_int,
-        description: *const ::std::os::raw::c_char,
-        metric: FaissMetricType,
-    ) -> ::std::os::raw::c_int;
-}
-pub type FaissIndexFlat = FaissIndex_H;
-extern "C" {
-    #[doc = " Opaque type for IndexFlat"]
-    pub fn faiss_IndexFlat_new(p_index: *mut *mut FaissIndexFlat) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexFlat_new_with(
-        p_index: *mut *mut FaissIndexFlat,
-        d: idx_t,
-        metric: FaissMetricType,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " get a pointer to the index's internal data (the `xb` field). The outputs\n become invalid after any data addition or removal operation.\n\n @param index   opaque pointer to index object\n @param p_xb    output, the pointer to the beginning of `xb`.\n @param p_size  output, the current size of `sb` in number of float values."]
-    pub fn faiss_IndexFlat_xb(index: *mut FaissIndexFlat, p_xb: *mut *mut f32, p_size: *mut usize);
-}
-extern "C" {
-    pub fn faiss_IndexFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlat;
-}
-extern "C" {
-    pub fn faiss_IndexFlat_free(obj: *mut FaissIndexFlat);
-}
-extern "C" {
-    #[doc = " compute distance with a subset of vectors\n\n @param index   opaque pointer to index object\n @param x       query vectors, size n * d\n @param labels  indices of the vectors that should be compared\n                for each query vector, size n * k\n @param distances\n                corresponding output distances, size n * k"]
-    pub fn faiss_IndexFlat_compute_distance_subset(
-        index: *mut FaissIndex,
-        n: idx_t,
-        x: *const f32,
-        k: idx_t,
-        distances: *mut f32,
-        labels: *const idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-pub type FaissIndexFlatIP = FaissIndex_H;
-extern "C" {
-    pub fn faiss_IndexFlatIP_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlatIP;
-}
-extern "C" {
-    pub fn faiss_IndexFlatIP_free(obj: *mut FaissIndexFlatIP);
-}
-extern "C" {
-    #[doc = " Opaque type for IndexFlatIP"]
-    pub fn faiss_IndexFlatIP_new(p_index: *mut *mut FaissIndexFlatIP) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexFlatIP_new_with(
-        p_index: *mut *mut FaissIndexFlatIP,
-        d: idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-pub type FaissIndexFlatL2 = FaissIndex_H;
-extern "C" {
-    pub fn faiss_IndexFlatL2_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlatL2;
-}
-extern "C" {
-    pub fn faiss_IndexFlatL2_free(obj: *mut FaissIndexFlatL2);
-}
-extern "C" {
-    #[doc = " Opaque type for IndexFlatL2"]
-    pub fn faiss_IndexFlatL2_new(p_index: *mut *mut FaissIndexFlatL2) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexFlatL2_new_with(
-        p_index: *mut *mut FaissIndexFlatL2,
-        d: idx_t,
-    ) -> ::std::os::raw::c_int;
-}
-pub type FaissIndexRefineFlat = FaissIndex_H;
-extern "C" {
-    #[doc = " Opaque type for IndexRefineFlat\n\n Index that queries in a base_index (a fast one) and refines the\n results with an exact search, hopefully improving the results."]
-    pub fn faiss_IndexRefineFlat_new(
-        p_index: *mut *mut FaissIndexRefineFlat,
-        base_index: *mut FaissIndex,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_free(obj: *mut FaissIndexRefineFlat);
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexRefineFlat;
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_own_fields(
-        arg1: *const FaissIndexRefineFlat,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_set_own_fields(
-        arg1: *mut FaissIndexRefineFlat,
-        arg2: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_k_factor(arg1: *const FaissIndexRefineFlat) -> f32;
-}
-extern "C" {
-    pub fn faiss_IndexRefineFlat_set_k_factor(arg1: *mut FaissIndexRefineFlat, arg2: f32);
-}
-pub type FaissIndexFlat1D = FaissIndex_H;
-extern "C" {
-    pub fn faiss_IndexFlat1D_cast(arg1: *mut FaissIndex) -> *mut FaissIndexFlat1D;
-}
-extern "C" {
-    pub fn faiss_IndexFlat1D_free(obj: *mut FaissIndexFlat1D);
-}
-extern "C" {
-    #[doc = " Opaque type for IndexFlat1D\n\n optimized version for 1D \"vectors\""]
-    pub fn faiss_IndexFlat1D_new(p_index: *mut *mut FaissIndexFlat1D) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexFlat1D_new_with(
-        p_index: *mut *mut FaissIndexFlat1D,
-        continuous_update: ::std::os::raw::c_int,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexFlat1D_update_permutation(
-        index: *mut FaissIndexFlat1D,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index` when a file descriptor is\n provided."]
-    pub fn faiss_write_index(idx: *const FaissIndex, f: *mut FILE) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index` when a file path is provided."]
-    pub fn faiss_write_index_fname(
-        idx: *const FaissIndex,
-        fname: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index` when a file descriptor is given."]
-    pub fn faiss_read_index(
-        f: *mut FILE,
-        io_flags: ::std::os::raw::c_int,
-        p_out: *mut *mut FaissIndex,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index` when a file path is given."]
-    pub fn faiss_read_index_fname(
-        fname: *const ::std::os::raw::c_char,
-        io_flags: ::std::os::raw::c_int,
-        p_out: *mut *mut FaissIndex,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index_binary` when a file descriptor is\n provided."]
-    pub fn faiss_write_index_binary(
-        idx: *const FaissIndexBinary,
-        f: *mut FILE,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index_binary` when a file path is\n provided."]
-    pub fn faiss_write_index_binary_fname(
-        idx: *const FaissIndexBinary,
-        fname: *const ::std::os::raw::c_char,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index_binary` when a file descriptor is\n given."]
-    pub fn faiss_read_index_binary(
-        f: *mut FILE,
-        io_flags: ::std::os::raw::c_int,
-        p_out: *mut *mut FaissIndexBinary,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index_binary` when a file path is given."]
-    pub fn faiss_read_index_binary_fname(
-        fname: *const ::std::os::raw::c_char,
-        io_flags: ::std::os::raw::c_int,
-        p_out: *mut *mut FaissIndexBinary,
-    ) -> ::std::os::raw::c_int;
-}
 pub type FaissSearchParametersIVF = FaissSearchParameters_H;
 extern "C" {
     pub fn faiss_SearchParametersIVF_free(obj: *mut FaissSearchParametersIVF);
@@ -1454,78 +1438,6 @@ extern "C" {
 extern "C" {
     #[doc = " global var that collects all statists"]
     pub fn faiss_get_indexIVF_stats() -> *mut FaissIndexIVFStats;
-}
-pub type FaissIndexIVFFlat = FaissIndex_H;
-extern "C" {
-    pub fn faiss_IndexIVFFlat_free(obj: *mut FaissIndexIVFFlat);
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_cast(arg1: *mut FaissIndex) -> *mut FaissIndexIVFFlat;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_nlist(arg1: *const FaissIndexIVFFlat) -> usize;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_nprobe(arg1: *const FaissIndexIVFFlat) -> usize;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_set_nprobe(arg1: *mut FaissIndexIVFFlat, arg2: usize);
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_quantizer(arg1: *const FaissIndexIVFFlat) -> *mut FaissIndex;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_quantizer_trains_alone(
-        arg1: *const FaissIndexIVFFlat,
-    ) -> ::std::os::raw::c_char;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_own_fields(arg1: *const FaissIndexIVFFlat) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_set_own_fields(
-        arg1: *mut FaissIndexIVFFlat,
-        arg2: ::std::os::raw::c_int,
-    );
-}
-extern "C" {
-    #[doc = " whether object owns the quantizer"]
-    pub fn faiss_IndexIVFFlat_new(p_index: *mut *mut FaissIndexIVFFlat) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_new_with(
-        p_index: *mut *mut FaissIndexIVFFlat,
-        quantizer: *mut FaissIndex,
-        d: usize,
-        nlist: usize,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_new_with_metric(
-        p_index: *mut *mut FaissIndexIVFFlat,
-        quantizer: *mut FaissIndex,
-        d: usize,
-        nlist: usize,
-        metric: FaissMetricType,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    pub fn faiss_IndexIVFFlat_add_core(
-        index: *mut FaissIndexIVFFlat,
-        n: idx_t,
-        x: *const f32,
-        xids: *const idx_t,
-        precomputed_idx: *const i64,
-    ) -> ::std::os::raw::c_int;
-}
-extern "C" {
-    #[doc = " Update a subset of vectors.\n\n The index must have a direct_map\n\n @param nv     nb of vectors to update\n @param idx    vector indices to update, size nv\n @param v      vectors of new values, size nv*d"]
-    pub fn faiss_IndexIVFFlat_update_vectors(
-        index: *mut FaissIndexIVFFlat,
-        nv: ::std::os::raw::c_int,
-        idx: *mut idx_t,
-        v: *const f32,
-    ) -> ::std::os::raw::c_int;
 }
 pub type FaissIndexLSH = FaissIndex_H;
 extern "C" {
@@ -2091,6 +2003,109 @@ extern "C" {
 extern "C" {
     #[doc = " get a pointer to the sub-index (the `index` field).\n The outputs of this function become invalid after any operation that can\n modify the index.\n\n @param index   opaque pointer to index object"]
     pub fn faiss_IndexIDMap2_sub_index(index: *mut FaissIndexIDMap2) -> *mut FaissIndex;
+}
+pub type FILE = [u64; 27usize];
+extern "C" {
+    #[doc = " Clone an index. This is equivalent to `faiss::clone_index`"]
+    pub fn faiss_clone_index(
+        arg1: *const FaissIndex,
+        p_out: *mut *mut FaissIndex,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Clone a binary index. This is equivalent to `faiss::clone_index_binary`"]
+    pub fn faiss_clone_index_binary(
+        arg1: *const FaissIndexBinary,
+        p_out: *mut *mut FaissIndexBinary,
+    ) -> ::std::os::raw::c_int;
+}
+#[doc = " No error"]
+pub const FaissErrorCode_OK: FaissErrorCode = 0;
+#[doc = " Any exception other than Faiss or standard C++ library exceptions"]
+pub const FaissErrorCode_UNKNOWN_EXCEPT: FaissErrorCode = -1;
+#[doc = " Faiss library exception"]
+pub const FaissErrorCode_FAISS_EXCEPT: FaissErrorCode = -2;
+#[doc = " Standard C++ library exception"]
+pub const FaissErrorCode_STD_EXCEPT: FaissErrorCode = -4;
+#[doc = " An error code which depends on the exception thrown from the previous\n operation. See `faiss_get_last_error` to retrieve the error message."]
+pub type FaissErrorCode = ::std::os::raw::c_int;
+extern "C" {
+    #[doc = " Get the error message of the last failed operation performed by Faiss.\n The given pointer is only invalid until another Faiss function is\n called."]
+    pub fn faiss_get_last_error() -> *const ::std::os::raw::c_char;
+}
+extern "C" {
+    #[doc = " Build an index with the sequence of processing steps described in\n  the string."]
+    pub fn faiss_index_factory(
+        p_index: *mut *mut FaissIndex,
+        d: ::std::os::raw::c_int,
+        description: *const ::std::os::raw::c_char,
+        metric: FaissMetricType,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Build a binary index with the sequence of processing steps described in\n  the string."]
+    pub fn faiss_index_binary_factory(
+        p_index: *mut *mut FaissIndexBinary,
+        d: ::std::os::raw::c_int,
+        description: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index` when a file descriptor is\n provided."]
+    pub fn faiss_write_index(idx: *const FaissIndex, f: *mut FILE) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index` when a file path is provided."]
+    pub fn faiss_write_index_fname(
+        idx: *const FaissIndex,
+        fname: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index` when a file descriptor is given."]
+    pub fn faiss_read_index(
+        f: *mut FILE,
+        io_flags: ::std::os::raw::c_int,
+        p_out: *mut *mut FaissIndex,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index` when a file path is given."]
+    pub fn faiss_read_index_fname(
+        fname: *const ::std::os::raw::c_char,
+        io_flags: ::std::os::raw::c_int,
+        p_out: *mut *mut FaissIndex,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index_binary` when a file descriptor is\n provided."]
+    pub fn faiss_write_index_binary(
+        idx: *const FaissIndexBinary,
+        f: *mut FILE,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Write index to a file.\n This is equivalent to `faiss::write_index_binary` when a file path is\n provided."]
+    pub fn faiss_write_index_binary_fname(
+        idx: *const FaissIndexBinary,
+        fname: *const ::std::os::raw::c_char,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index_binary` when a file descriptor is\n given."]
+    pub fn faiss_read_index_binary(
+        f: *mut FILE,
+        io_flags: ::std::os::raw::c_int,
+        p_out: *mut *mut FaissIndexBinary,
+    ) -> ::std::os::raw::c_int;
+}
+extern "C" {
+    #[doc = " Read index from a file.\n This is equivalent to `faiss:read_index_binary` when a file path is given."]
+    pub fn faiss_read_index_binary_fname(
+        fname: *const ::std::os::raw::c_char,
+        io_flags: ::std::os::raw::c_int,
+        p_out: *mut *mut FaissIndexBinary,
+    ) -> ::std::os::raw::c_int;
 }
 extern "C" {
     #[doc = " Compute pairwise distances between sets of vectors"]

--- a/faiss-sys/src/lib.rs
+++ b/faiss-sys/src/lib.rs
@@ -31,6 +31,21 @@ mod tests {
             assert!(!last_error.is_null());
         }
     }
+    #[test]
+    fn flat_index_binary() {
+        const D: usize = 8;
+        unsafe {
+            let description =
+                CString::new::<&str>("BFlat".as_ref()).unwrap();
+            let mut index_ptr = ::std::ptr::null_mut();
+            let code = faiss_index_binary_factory(
+                &mut index_ptr,
+                (D & 0x7FFF_FFFF) as i32,
+                description.as_ptr(),
+            );
+            assert_eq!(code, 0);
+        }
+    }
 
     #[test]
     fn flat_index() {

--- a/src/index/io.rs
+++ b/src/index/io.rs
@@ -2,7 +2,10 @@
 
 use crate::error::{Error, Result};
 use crate::faiss_try;
-use crate::index::{CpuIndex, FromInnerPtr, IndexImpl, NativeIndex};
+use crate::index::{
+    CpuIndex, FromInnerPtr, IndexImpl, NativeIndex, 
+    CpuIndexBinary, FromInnerPtrBinary, BinaryIndexImpl, NativeIndexBinary
+};
 use faiss_sys::*;
 use std::ffi::CString;
 use std::os::raw::c_int;
@@ -31,6 +34,28 @@ where
     }
 }
 
+
+/// Write a binary index to a file.
+///
+/// # Error
+///
+/// This function returns an error if the description contains any byte with the value `\0` (since
+/// it cannot be converted to a C string), or if the internal index writing operation fails.
+pub fn write_index_binary<I, P>(index: &I, file_name: P) -> Result<()>
+where
+    I: NativeIndexBinary,
+    I: CpuIndexBinary,
+    P: AsRef<str>,
+{
+    unsafe {
+        let f = file_name.as_ref();
+        let f = CString::new(f).map_err(|_| Error::BadFilePath)?;
+
+        faiss_try(faiss_write_index_binary_fname(index.inner_ptr(), f.as_ptr()))?;
+        Ok(())
+    }
+}
+
 /// Read an index from a file.
 ///
 /// # Error
@@ -51,6 +76,30 @@ where
             &mut inner,
         ))?;
         Ok(IndexImpl::from_inner_ptr(inner))
+    }
+}
+
+
+/// Read a binary index from a file.
+///
+/// # Error
+///
+/// This function returns an error if the description contains any byte with the value `\0` (since
+/// it cannot be converted to a C string), or if the internal index reading operation fails.
+pub fn read_index_binary<P>(file_name: P) -> Result<BinaryIndexImpl>
+where
+    P: AsRef<str>,
+{
+    unsafe {
+        let f = file_name.as_ref();
+        let f = CString::new(f).map_err(|_| Error::BadFilePath)?;
+        let mut inner = ptr::null_mut();
+        faiss_try(faiss_read_index_binary_fname(
+            f.as_ptr(),
+            IoFlags::MEM_RESIDENT.into(),
+            &mut inner,
+        ))?;
+        Ok(BinaryIndexImpl::from_inner_ptr(inner))
     }
 }
 
@@ -78,6 +127,33 @@ where
         Ok(IndexImpl::from_inner_ptr(inner))
     }
 }
+
+
+/// Read a binary index from a file with I/O flags.
+///
+/// You can memory map some index types with this.
+///
+/// # Error
+///
+/// This function returns an error if the description contains any byte with the value `\0` (since
+/// it cannot be converted to a C string), or if the internal index reading operation fails.
+pub fn read_index_binary_with_flags<P>(file_name: P, io_flags: IoFlags) -> Result<BinaryIndexImpl>
+where
+    P: AsRef<str>,
+{
+    unsafe {
+        let f = file_name.as_ref();
+        let f = CString::new(f).map_err(|_| Error::BadFilePath)?;
+        let mut inner = ptr::null_mut();
+        faiss_try(faiss_read_index_binary_fname(
+            f.as_ptr(),
+            io_flags.0 as c_int,
+            &mut inner,
+        ))?;
+        Ok(BinaryIndexImpl::from_inner_ptr(inner))
+    }
+}
+
 
 #[cfg(test)]
 mod tests {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -927,13 +927,20 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{index_factory, Idx, Index, TryClone};
+    use super::{index_factory, Idx, Index, TryClone, index_binary_factory, IndexBinary};
     use crate::metric::MetricType;
 
     #[test]
     fn index_factory_flat() {
         let index = index_factory(64, "Flat", MetricType::L2).unwrap();
         assert_eq!(index.is_trained(), true); // Flat index does not need training
+        assert_eq!(index.ntotal(), 0);
+    }
+
+    #[test]
+    fn index_binary_factory_flat() {
+        let index = index_binary_factory(64, "BFlat").unwrap();
+        assert_eq!(index.is_trained(), true); // BFlat index does not need training
         assert_eq!(index.ntotal(), 0);
     }
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -126,6 +126,69 @@ impl PartialOrd<Idx> for Idx {
     }
 }
 
+
+/// Interface for a Faiss binary index. Most methods in this trait match the ones in
+/// the native library, whereas some others serve as getters to the index'
+/// parameters.
+///
+/// Although all methods appear to be available for all binary index implementations,
+/// some methods may not be supported. For instance, a [`BinaryFlatIndex`] stores
+/// vectors sequentially, and so does not support `add_with_ids` nor
+/// `remove_ids`. Users are advised to read the Faiss wiki pages in order
+/// to understand which index algorithms support which operations.
+///
+/// [`BinaryFlatIndex`]: flat/struct.BinaryFlatIndex.html
+pub trait IndexBinary {
+
+    /// Whether the BinaryIndex does not require training, or if training is done already
+    fn is_trained(&self) -> bool;
+
+    /// The total number of vectors indexed
+    fn ntotal(&self) -> u64;
+
+    /// The dimensionality of the indexed vectors
+    fn d(&self) -> u32;
+
+    /// The metric type assumed by the index
+    fn metric_type(&self) -> MetricType;
+
+    /// Add new data vectors to the index.
+    /// This assumes a C-contiguous memory slice of vectors, where the total
+    /// number of vectors is `x.len() / d`.
+    fn add(&mut self, x: &[u8]) -> Result<()>;
+
+    /// Add new data vectors to the index with IDs.
+    /// This assumes a C-contiguous memory slice of vectors, where the total
+    /// number of vectors is `x.len() / d`.
+    /// Not all index types may support this operation.
+    fn add_with_ids(&mut self, x: &[u8], xids: &[Idx]) -> Result<()>;
+
+    /// Train the underlying index with the given data.
+    fn train(&mut self, x: &[u8]) -> Result<()>;
+
+    /// Similar to `search`, but only provides the labels.
+    fn assign(&mut self, q: &[u8], k: usize) -> Result<AssignSearchResult>;
+
+    /// Perform a search for the `k` closest vectors to the given query vectors.
+    fn search(&mut self, q: &[u8], k: usize) -> Result<SearchResultBinary>;
+
+    /// Perform a ranged search for the vectors closest to the given query vectors
+    /// by the given radius.
+    fn range_search(&mut self, q: &[u8], radius: i32) -> Result<RangeSearchResult>;
+
+    /// Clear the entire index.
+    fn reset(&mut self) -> Result<()>;
+
+    /// Remove data vectors represented by IDs.
+    fn remove_ids(&mut self, sel: &IdSelector) -> Result<usize>;
+
+    /// Index verbosity level
+    fn verbose(&self) -> bool;
+
+    /// Set Index verbosity level
+    fn set_verbose(&mut self, value: bool);
+}
+
 /// Interface for a Faiss index. Most methods in this trait match the ones in
 /// the native library, whereas some others serve as getters to the index'
 /// parameters.
@@ -185,6 +248,67 @@ pub trait Index {
 
     /// Set Index verbosity level
     fn set_verbose(&mut self, value: bool);
+}
+
+impl<BI> IndexBinary for Box<BI>
+where
+    BI: IndexBinary
+{
+    fn is_trained(&self) -> bool {
+        (**self).is_trained()
+    }
+
+    fn ntotal(&self) -> u64 {
+        (**self).ntotal()
+    }
+
+    fn d(&self) -> u32 {
+        (**self).d()
+    }
+
+    fn metric_type(&self) -> MetricType {
+        (**self).metric_type()
+    }
+
+    fn add(&mut self, x: &[u8]) -> Result<()> {
+        (**self).add(x)
+    }
+
+    fn add_with_ids(&mut self, x: &[u8], xids: &[Idx]) -> Result<()> {
+        (**self).add_with_ids(x, xids)
+    }
+
+    fn train(&mut self, x: &[u8]) -> Result<()> {
+        (**self).train(x)
+    }
+
+    fn assign(&mut self, q: &[u8], k: usize) -> Result<AssignSearchResult> {
+        (**self).assign(q, k)
+    }
+
+    fn search(&mut self, q: &[u8], k: usize) -> Result<SearchResultBinary> {
+        (**self).search(q, k)
+    }
+
+    fn range_search(&mut self, q: &[u8], radius: i32) -> Result<RangeSearchResult> {
+        (**self).range_search(q, radius)
+    }
+
+    fn reset(&mut self) -> Result<()> {
+        (**self).reset()
+    }
+
+    fn remove_ids(&mut self, sel: &IdSelector) -> Result<usize> {
+        (**self).remove_ids(sel)
+    }
+
+    fn verbose(&self) -> bool {
+        (**self).verbose()
+    }
+
+    fn set_verbose(&mut self, value: bool) {
+        (**self).set_verbose(value)
+    }
 }
 
 impl<I> Index for Box<I>
@@ -247,6 +371,96 @@ where
         (**self).set_verbose(value)
     }
 }
+
+/// Sub-trait for native implementations of a Faiss binary index.
+pub trait NativeIndexBinary: IndexBinary {
+    /// Retrieve a pointer to the native index object.
+    fn inner_ptr(&self) -> *mut FaissIndexBinary;
+}
+
+impl<NIB: NativeIndexBinary> NativeIndexBinary for Box<NIB> {
+    fn inner_ptr(&self) -> *mut FaissIndexBinary {
+        (**self).inner_ptr()
+    }
+}
+
+/// Trait for a Faiss binary index that can be safely searched over multiple threads.
+/// Operations which do not modify the index are given a method taking an
+/// immutable reference. This is not the default for every index type because
+/// some implementations (such as the ones running on the GPU) do not allow
+/// concurrent searches.
+///
+/// Users of these methods should still note that batched querying is
+/// considerably faster than running queries one by one, even in parallel.
+pub trait ConcurrentIndexBinary: IndexBinary {
+    /// Similar to `search`, but only provides the labels.
+    fn assign(&self, q: &[u8], k: usize) -> Result<AssignSearchResult>;
+
+    /// Perform a search for the `k` closest vectors to the given query vectors.
+    fn search(&self, q: &[u8], k: usize) -> Result<SearchResult>;
+
+    /// Perform a ranged search for the vectors closest to the given query vectors
+    /// by the given radius.
+    fn range_search(&self, q: &[u8], radius: i32) -> Result<RangeSearchResult>;
+}
+
+
+impl<CIB: ConcurrentIndexBinary> ConcurrentIndexBinary for Box<CIB> {
+    fn assign(&self, q: &[u8], k: usize) -> Result<AssignSearchResult> {
+        (**self).assign(q, k)
+    }
+
+    fn search(&self, q: &[u8], k: usize) -> Result<SearchResult> {
+        (**self).search(q, k)
+    }
+
+    fn range_search(&self, q: &[u8], radius: i32) -> Result<RangeSearchResult> {
+        (**self).range_search(q, radius)
+    }
+}
+
+
+/// Trait for Faiss index types known to be running on the CPU.
+pub trait CpuIndexBinary: IndexBinary {}
+
+impl<CIB: CpuIndexBinary> CpuIndexBinary for Box<CIB> {}
+
+/// Trait for Faiss binary index types which can be built from a pointer
+/// to a native implementation.
+pub trait FromInnerPtrBinary: NativeIndexBinary {
+    /// Create a binary index using the given pointer to a native object.
+    ///
+    /// # Safety
+    ///
+    /// `inner_ptr` must point to a valid, non-freed CPU binary index, and cannot be
+    /// shared across multiple instances. The inner binary index must also be
+    /// compatible with the target `NativeIndexBinary` type according to the native
+    /// class hierarchy. For example, creating an `BinaryIndexImpl` out of a pointer
+    /// to `FaissIndexBinaryFlat` is valid, but creating a `FlatIndexBinary` out of a
+    /// plain `FaissIndexBinary` can cause undefined behavior.
+    unsafe fn from_inner_ptr(inner_ptr: *mut FaissIndexBinary) -> Self;
+}
+
+/// Trait for Faiss binary index types which can be built from a pointer
+/// to a native implementation.
+pub trait TryFromInnerPtrBinary: NativeIndexBinary {
+    /// Create a binary index using the given pointer to a native object,
+    /// checking that the binary index behind the given pointer
+    /// is compatible with the target index type.
+    /// If the inner index is not compatible with the intended target type
+    /// (e.g. creating a `FlatIndexBinary` out of a `FaissIndexBinaryHNSW`),
+    /// an error is returned.
+    ///
+    /// # Safety
+    ///
+    /// This function is unable to check that
+    /// `inner_ptr` points to a valid, non-freed CPU binary index.
+    /// Moreover, `inner_ptr` must not be shared across multiple instances.
+    unsafe fn try_from_inner_ptr(inner_ptr: *mut FaissIndexBinary) -> Result<Self>
+    where
+        Self: Sized;
+}
+
 
 /// Sub-trait for native implementations of a Faiss index.
 pub trait NativeIndex: Index {
@@ -359,6 +573,17 @@ where
     }
 }
 
+pub fn try_clone_from_inner_ptr_binary<T>(val: &T) -> Result<T>
+where
+    T: FromInnerPtrBinary,
+{
+    unsafe {
+        let mut new_index_ptr = ::std::ptr::null_mut();
+        faiss_try(faiss_clone_index_binary(val.inner_ptr(), &mut new_index_ptr))?;
+        Ok(crate::index::FromInnerPtrBinary::from_inner_ptr(new_index_ptr))
+    }
+}
+
 /// The outcome of an index assign operation.
 #[derive(Debug, Clone, PartialEq)]
 pub struct AssignSearchResult {
@@ -369,6 +594,13 @@ pub struct AssignSearchResult {
 #[derive(Debug, Clone, PartialEq)]
 pub struct SearchResult {
     pub distances: Vec<f32>,
+    pub labels: Vec<Idx>,
+}
+
+/// The outcome of an index search operation.
+#[derive(Debug, Clone, PartialEq)]
+pub struct SearchResultBinary {
+    pub distances: Vec<i32>,
     pub labels: Vec<Idx>,
 }
 
@@ -460,10 +692,21 @@ pub struct IndexImpl {
     inner: *mut FaissIndex,
 }
 
+/// Native implementation of a Faiss binary index
+/// running on the CPU.
+#[derive(Debug)]
+pub struct BinaryIndexImpl {
+    inner: *mut FaissIndexBinary,
+}
+
 unsafe impl Send for IndexImpl {}
 unsafe impl Sync for IndexImpl {}
 
+unsafe impl Send for BinaryIndexImpl {}
+unsafe impl Sync for BinaryIndexImpl {}
+
 impl CpuIndex for IndexImpl {}
+impl CpuIndexBinary for BinaryIndexImpl {}
 
 impl Drop for IndexImpl {
     fn drop(&mut self) {
@@ -473,8 +716,30 @@ impl Drop for IndexImpl {
     }
 }
 
+
+impl Drop for BinaryIndexImpl {
+    fn drop(&mut self) {
+        unsafe {
+            faiss_IndexBinary_free(self.inner);
+        }
+    }
+}
+
+impl BinaryIndexImpl {
+    pub fn inner_ptr(&self) -> *mut FaissIndexBinary {
+        self.inner
+    }
+}
+
 impl IndexImpl {
     pub fn inner_ptr(&self) -> *mut FaissIndex {
+        self.inner
+    }
+}
+
+
+impl NativeIndexBinary for BinaryIndexImpl {
+    fn inner_ptr(&self) -> *mut FaissIndexBinary {
         self.inner
     }
 }
@@ -482,6 +747,12 @@ impl IndexImpl {
 impl NativeIndex for IndexImpl {
     fn inner_ptr(&self) -> *mut FaissIndex {
         self.inner
+    }
+}
+
+impl FromInnerPtrBinary for BinaryIndexImpl {
+    unsafe fn from_inner_ptr(inner_ptr: *mut FaissIndexBinary) -> Self {
+        BinaryIndexImpl { inner: inner_ptr }
     }
 }
 
@@ -500,6 +771,19 @@ impl TryFromInnerPtr for IndexImpl {
             Err(Error::BadCast)
         } else {
             Ok(IndexImpl { inner: inner_ptr })
+        }
+    }
+}
+
+impl TryFromInnerPtrBinary for BinaryIndexImpl {
+    unsafe fn try_from_inner_ptr(inner_ptr: *mut FaissIndexBinary) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        if inner_ptr.is_null() {
+            Err(Error::BadCast)
+        } else {
+            Ok(BinaryIndexImpl { inner: inner_ptr })
         }
     }
 }
@@ -525,6 +809,28 @@ pub trait UpcastIndex: NativeIndex {
     fn upcast(self) -> IndexImpl;
 }
 
+
+/// BinaryIndex upcast trait.
+///
+/// If you need to store several different types of binary indexes in one collection,
+/// you can cast all binary indexes to the common type `BinaryIndexImpl`.
+/// # Examples
+///
+/// ```
+/// # use faiss::{index::{BinaryIndexImpl, UpcastIndexBinary}, BinaryFlatIndex, index_binary_factory};
+/// let f1 = BinaryFlatIndex::new(128).unwrap();
+/// let f2 = index_binary_factory(128, "BFlat").unwrap();
+/// let v: Vec<BinaryIndexImpl> = vec![
+///     f1.upcast(),
+///     f2,
+/// ];
+/// ```
+///
+pub trait UpcastIndexBinary: NativeIndexBinary {
+    /// Convert an index to the base `BinaryIndexImpl` type
+    fn upcast(self) -> BinaryIndexImpl;
+}
+
 impl<NI: NativeIndex> UpcastIndex for NI {
     fn upcast(self) -> IndexImpl {
         let inner_ptr = self.inner_ptr();
@@ -534,7 +840,18 @@ impl<NI: NativeIndex> UpcastIndex for NI {
     }
 }
 
+
+impl<NIB: NativeIndexBinary> UpcastIndexBinary for NIB {
+    fn upcast(self) -> BinaryIndexImpl {
+        let inner_ptr = self.inner_ptr();
+        mem::forget(self);
+
+        unsafe { BinaryIndexImpl::from_inner_ptr(inner_ptr) }
+    }
+}
+
 impl_native_index!(IndexImpl);
+impl_native_binary_index!(BinaryIndexImpl);
 
 impl TryClone for IndexImpl {
     fn try_clone(&self) -> Result<Self>
@@ -542,6 +859,16 @@ impl TryClone for IndexImpl {
         Self: Sized,
     {
         try_clone_from_inner_ptr(self)
+    }
+}
+
+
+impl TryClone for BinaryIndexImpl {
+    fn try_clone(&self) -> Result<Self>
+    where
+        Self: Sized,
+    {
+        try_clone_from_inner_ptr_binary(self)
     }
 }
 
@@ -569,6 +896,32 @@ where
             metric,
         ))?;
         Ok(IndexImpl { inner: index_ptr })
+    }
+}
+
+
+/// Use the index binary factory to create a native instance of a Faiss binary index, for `d`-dimensional
+/// vectors. `description` should follow the exact guidelines as the native Faiss interface
+/// (see the [Faiss wiki](https://github.com/facebookresearch/faiss/wiki/Binary-indexes) for examples).
+///
+/// # Error
+///
+/// This function returns an error if the description contains any byte with the value `\0` (since
+/// it cannot be converted to a C string), or if the internal index factory operation fails.
+pub fn index_binary_factory<D>(d: u32, description: D) -> Result<BinaryIndexImpl>
+where
+    D: AsRef<str>,
+{
+    unsafe {
+        let description =
+            CString::new(description.as_ref()).map_err(|_| Error::IndexDescription)?;
+        let mut index_ptr = ::std::ptr::null_mut();
+        faiss_try(faiss_index_binary_factory(
+            &mut index_ptr,
+            (d & 0x7FFF_FFFF) as i32,
+            description.as_ptr(),
+        ))?;
+        Ok(BinaryIndexImpl { inner: index_ptr })
     }
 }
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -397,7 +397,7 @@ pub trait ConcurrentIndexBinary: IndexBinary {
     fn assign(&self, q: &[u8], k: usize) -> Result<AssignSearchResult>;
 
     /// Perform a search for the `k` closest vectors to the given query vectors.
-    fn search(&self, q: &[u8], k: usize) -> Result<SearchResult>;
+    fn search(&self, q: &[u8], k: usize) -> Result<SearchResultBinary>;
 
     /// Perform a ranged search for the vectors closest to the given query vectors
     /// by the given radius.
@@ -410,7 +410,7 @@ impl<CIB: ConcurrentIndexBinary> ConcurrentIndexBinary for Box<CIB> {
         (**self).assign(q, k)
     }
 
-    fn search(&self, q: &[u8], k: usize) -> Result<SearchResult> {
+    fn search(&self, q: &[u8], k: usize) -> Result<SearchResultBinary> {
         (**self).search(q, k)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,9 +100,12 @@ pub mod gpu;
 
 pub use index::flat::FlatIndex;
 pub use index::id_map::IdMap;
-pub use index::io::{read_index, write_index};
+pub use index::io::{read_index, write_index, read_index_binary, write_index_binary};
 pub use index::lsh::LshIndex;
-pub use index::{index_factory, ConcurrentIndex, Idx, Index};
+pub use index::{
+    index_factory, ConcurrentIndex, Idx, Index,
+    index_binary_factory, ConcurrentIndexBinary, IndexBinary,
+};
 pub use metric::MetricType;
 
 #[cfg(feature = "gpu")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -176,7 +176,205 @@ macro_rules! impl_native_index {
     };
 }
 
+
+/// A macro which provides a native binary index implementation to the given type.
+macro_rules! impl_native_binary_index {
+    ($t:ty) => {
+        impl crate::index::IndexBinary for $t {
+            fn is_trained(&self) -> bool {
+                unsafe { faiss_IndexBinary_is_trained(self.inner_ptr()) != 0 }
+            }
+
+            fn ntotal(&self) -> u64 {
+                unsafe { faiss_IndexBinary_ntotal(self.inner_ptr()) as u64 }
+            }
+
+            fn d(&self) -> u32 {
+                unsafe { faiss_IndexBinary_d(self.inner_ptr()) as u32 }
+            }
+
+            fn metric_type(&self) -> crate::metric::MetricType {
+                unsafe {
+                    crate::metric::MetricType::from_code(
+                        faiss_IndexBinary_metric_type(self.inner_ptr()) as u32
+                    )
+                    .unwrap()
+                }
+            }
+
+            fn add(&mut self, x: &[u8]) -> Result<()> {
+                unsafe {
+                    let n = x.len() / self.d() as usize;
+                    faiss_try(faiss_IndexBinary_add(self.inner_ptr(), n as i64, x.as_ptr()))?;
+                    Ok(())
+                }
+            }
+
+            fn add_with_ids(&mut self, x: &[u8], xids: &[crate::index::Idx]) -> Result<()> {
+                unsafe {
+                    let n = x.len() / self.d() as usize;
+                    faiss_try(faiss_IndexBinary_add_with_ids(
+                        self.inner_ptr(),
+                        n as i64,
+                        x.as_ptr(),
+                        xids.as_ptr() as *const _,
+                    ))?;
+                    Ok(())
+                }
+            }
+            fn train(&mut self, x: &[u8]) -> Result<()> {
+                unsafe {
+                    let n = x.len() / self.d() as usize;
+                    faiss_try(faiss_IndexBinary_train(self.inner_ptr(), n as i64, x.as_ptr()))?;
+                    Ok(())
+                }
+            }
+            fn assign(
+                &mut self,
+                query: &[u8],
+                k: usize,
+            ) -> Result<crate::index::AssignSearchResult> {
+                unsafe {
+                    let nq = query.len() / self.d() as usize;
+                    let mut out_labels = vec![Idx::none(); k * nq];
+                    faiss_try(faiss_IndexBinary_assign(
+                        self.inner_ptr(),
+                        nq as idx_t,
+                        query.as_ptr(),
+                        out_labels.as_mut_ptr() as *mut _,
+                        k as i64,
+                    ))?;
+                    Ok(crate::index::AssignSearchResult { labels: out_labels })
+                }
+            }
+            fn search(&mut self, query: &[u8], k: usize) -> Result<crate::index::SearchResultBinary> {
+                unsafe {
+                    let nq = query.len() / self.d() as usize;
+                    let mut distances = vec![0_i32; k * nq];
+                    let mut labels = vec![Idx::none(); k * nq];
+                    faiss_try(faiss_IndexBinary_search(
+                        self.inner_ptr(),
+                        nq as idx_t,
+                        query.as_ptr(),
+                        k as idx_t,
+                        distances.as_mut_ptr(),
+                        labels.as_mut_ptr() as *mut _,
+                    ))?;
+                    Ok(crate::index::SearchResultBinary { distances, labels })
+                }
+            }
+            fn range_search(
+                &mut self,
+                query: &[u8],
+                radius: i32,
+            ) -> Result<crate::index::RangeSearchResult> {
+                unsafe {
+                    let nq = (query.len() / self.d() as usize) as idx_t;
+                    let mut p_res: *mut FaissRangeSearchResult = ::std::ptr::null_mut();
+                    faiss_try(faiss_RangeSearchResult_new(&mut p_res, nq))?;
+                    faiss_try(faiss_IndexBinary_range_search(
+                        self.inner_ptr(),
+                        nq,
+                        query.as_ptr(),
+                        radius,
+                        p_res,
+                    ))?;
+                    Ok(crate::index::RangeSearchResult { inner: p_res })
+                }
+            }
+
+            fn reset(&mut self) -> Result<()> {
+                unsafe {
+                    faiss_try(faiss_IndexBinary_reset(self.inner_ptr()))?;
+                    Ok(())
+                }
+            }
+
+            fn remove_ids(&mut self, sel: &IdSelector) -> Result<usize> {
+                unsafe {
+                    let mut n_removed = 0;
+                    faiss_try(faiss_IndexBinary_remove_ids(
+                        self.inner_ptr(),
+                        sel.inner_ptr(),
+                        &mut n_removed,
+                    ))?;
+                    Ok(n_removed)
+                }
+            }
+
+            fn verbose(&self) -> bool {
+                unsafe { faiss_IndexBinary_verbose(self.inner_ptr()) != 0 }
+            }
+
+            fn set_verbose(&mut self, value: bool) {
+                unsafe {
+                    faiss_IndexBinary_set_verbose(self.inner_ptr(), std::os::raw::c_int::from(value));
+                }
+            }
+        }
+    };
+}
+
 /// A macro which provides a concurrent index implementation to the given type.
+macro_rules! impl_concurrent_binary_index {
+    ($t:ty) => {
+        impl crate::index::ConcurrentIndexBinary for $t
+        where
+            Self: crate::index::IndexBinary + crate::index::NativeIndexBinary,
+        {
+            fn assign(&self, query: &[u8], k: usize) -> Result<AssignSearchResult> {
+                unsafe {
+                    let nq = query.len() / self.d() as usize;
+                    let mut out_labels = vec![Idx::none(); k * nq];
+                    faiss_try(faiss_IndexBinary_assign(
+                        self.inner_ptr(),
+                        nq as idx_t,
+                        query.as_ptr(),
+                        out_labels.as_mut_ptr() as *mut _,
+                        k as i64,
+                    ))?;
+                    Ok(AssignSearchResult { labels: out_labels })
+                }
+            }
+
+            fn search(&self, query: &[u8], k: usize) -> Result<SearchResultBinary> {
+                unsafe {
+                    let nq = query.len() / self.d() as usize;
+                    let mut distances = vec![0_i32; k * nq];
+                    let mut labels = vec![Idx::none(); k * nq];
+                    faiss_try(faiss_IndexBinary_search(
+                        self.inner_ptr(),
+                        nq as idx_t,
+                        query.as_ptr(),
+                        k as idx_t,
+                        distances.as_mut_ptr(),
+                        labels.as_mut_ptr() as *mut _,
+                    ))?;
+                    Ok(SearchResult { distances, labels })
+                }
+            }
+
+            fn range_search(&self, query: &[u8], radius: i32) -> Result<RangeSearchResult> {
+                unsafe {
+                    let nq = (query.len() / self.d() as usize) as idx_t;
+                    let mut p_res: *mut FaissRangeSearchResult = ptr::null_mut();
+                    faiss_try(faiss_RangeSearchResult_new(&mut p_res, nq))?;
+                    faiss_try(faiss_IndexBinary_range_search(
+                        self.inner_ptr(),
+                        nq,
+                        query.as_ptr(),
+                        radius,
+                        p_res,
+                    ))?;
+                    Ok(RangeSearchResult { inner: p_res })
+                }
+            }
+        }
+    };
+}
+
+
+/// A macro which provides a concurrent binary index implementation to the given type.
 macro_rules! impl_concurrent_index {
     ($t:ty) => {
         impl crate::index::ConcurrentIndex for $t

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -350,7 +350,7 @@ macro_rules! impl_concurrent_binary_index {
                         distances.as_mut_ptr(),
                         labels.as_mut_ptr() as *mut _,
                     ))?;
-                    Ok(SearchResult { distances, labels })
+                    Ok(SearchResultBinary { distances, labels })
                 }
             }
 


### PR DESCRIPTION
This is an attempt to provide first-class support for Faiss binary indexes consuming the C API (along with a couple of utility functions introduced in facebookresearch/faiss#3318)

*Note*: #77 got merged so this is in lieu of #79 

This should be complete in terms of functionality (at least for a default `BinaryIndexImpl`) so I'm hoping to learn of any major concerns before continuing down this path and adding the `IndexBinaryFlat`, `IndexBinaryHNSW`, etc, concrete impls.