### PR TITLE
[faiss-sys][static] check the lib64 directory as well for newer compilers

### DIFF
--- a/faiss-sys/build.rs
+++ b/faiss-sys/build.rs
@@ -11,20 +11,24 @@ fn static_link_faiss() {
     cfg.define("FAISS_ENABLE_C_API", "ON")
         .define("BUILD_SHARED_LIBS", "OFF")
         .define("CMAKE_BUILD_TYPE", "Release")
-        .define("FAISS_ENABLE_GPU", if cfg!(feature = "gpu") {
-            "ON"
-        } else {
-            "OFF"
-        })
+        .define(
+            "FAISS_ENABLE_GPU",
+            if cfg!(feature = "gpu") { "ON" } else { "OFF" },
+        )
         .define("FAISS_ENABLE_PYTHON", "OFF")
         .define("BUILD_TESTING", "OFF")
         .very_verbose(true);
     let dst = cfg.build();
     let faiss_location = dst.join("lib");
+    let faiss64_location = dst.join("lib64");
     let faiss_c_location = dst.join("build/c_api");
     println!(
         "cargo:rustc-link-search=native={}",
         faiss_location.display()
+    );
+    println!(
+        "cargo:rustc-link-search=native={}",
+        faiss64_location.display()
     );
     println!(
         "cargo:rustc-link-search=native={}",


### PR DESCRIPTION
I had the same issue as #82 -- the linker error that wasn't obvious.

I did a little digging (`cargo build --verbose`) and looking in the search paths... and it looks like my compiler outputs the static library to `lib64/` instead of just `lib/`

While I'm not sure exactly why, adding `lib64/` to the search path (as per this PR) made everything just work.