### PR TITLE
fix: build on windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,6 @@ path = "faiss-sys"
 
 [package.metadata.docs.rs]
 features = ["gpu"]
+
+[workspace]
+members = ["faiss-sys"]

--- a/faiss-sys/Cargo.toml
+++ b/faiss-sys/Cargo.toml
@@ -2,6 +2,7 @@
 name = "faiss-sys"
 description = "Native bindings for Faiss"
 version = "0.6.3-alpha.0"
+edition = "2021"
 authors = ["Eduardo Pinho <enet4mikeenet@gmail.com>"]
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Enet4/faiss-rs"


### PR DESCRIPTION
This library previously would not build on Windows. There are a few tricky parts that are not the fault of `faiss-rs` (ex.: you need to set `MKL_ROOT` env variable because CMake on Windows cannot locate Intel MKL automatically, and then it fails because no BLAS) but are maybe worth documenting. This PR is about fixing the library search path, though.

When I compile FAISS with CMake & MSVC on Windows, I get a build folder structure that looks like this:
```
C:\USERS\IBIYEMI\PROJECTS\NOT-MINE\FAISS\BUILD
│   ALL_BUILD.vcxproj
│   ALL_BUILD.vcxproj.filters
│   CMakeCache.txt
│   cmake_install.cmake
│   faiss.sln
│   INSTALL.vcxproj
│   INSTALL.vcxproj.filters
│   ZERO_CHECK.vcxproj
│   ZERO_CHECK.vcxproj.filters
│
├───c_api
│   │   ALL_BUILD.vcxproj
│   │   ALL_BUILD.vcxproj.filters
│   │   cmake_install.cmake
│   │   example_c.vcxproj
│   │   example_c.vcxproj.filters
│   │   faiss_c.vcxproj
│   │   faiss_c.vcxproj.filters
│   │   faiss_c_library.sln
│   │   INSTALL.vcxproj
│   │   INSTALL.vcxproj.filters
│   │
│   ├───CMakeFiles
│   │       generate.stamp
│   │       generate.stamp.depend
│   │
│   ├───faiss_c.dir
│   │   └───Release
│   │       │   AutoTune_c.obj
│   │       │   AuxIndexStructures_c.obj
│   │       │   clone_index_c.obj
│   │       │   (more object files, omitted for brevity)
│   │       │   MetaIndexes_c.obj
│   │       │   utils_c.obj
│   │       │   VectorTransform_c.obj
│   │       │
│   │       └───faiss_c.tlog
│   │               CL.command.1.tlog
│   │               Cl.items.tlog
│   │               CL.read.1.tlog
│   │               CL.write.1.tlog
│   │               CustomBuild.command.1.tlog
│   │               CustomBuild.read.1.tlog
│   │               CustomBuild.write.1.tlog
│   │               faiss_c.lastbuildstate
│   │               Lib-link.read.1.tlog
│   │               Lib-link.write.1.tlog
│   │               Lib.command.1.tlog
│   │
│   └───Release
│           faiss_c.lib
│
├───faiss
│   │   cmake_install.cmake
│   │   faiss.vcxproj
│   │   faiss.vcxproj.filters
│   │   faiss_avx2.vcxproj
│   │   faiss_avx2.vcxproj.filters
│   │   faiss_avx512.vcxproj
│   │   faiss_avx512.vcxproj.filters
│   │   faiss_avx512_spr.vcxproj
│   │   faiss_avx512_spr.vcxproj.filters
│   │   faiss_sve.vcxproj
│   │   faiss_sve.vcxproj.filters
│   │   INSTALL.vcxproj
│   │   INSTALL.vcxproj.filters
│   │
│   ├───CMakeFiles
│   │   │   generate.stamp
│   │   │   generate.stamp.depend
│   │   │
│   │   └───Export
│   │       └───5de5d61945e1ac7c8fc01cce1738f759
│   │               faiss-targets-debug.cmake
│   │               faiss-targets-minsizerel.cmake
│   │               faiss-targets-release.cmake
│   │               faiss-targets-relwithdebinfo.cmake
│   │               faiss-targets.cmake
│   │
│   ├───faiss.dir
│   │   └───Release
│   │       │   AdditiveQuantizer.obj
│   │       │   AutoTune.obj
│   │       │   AuxIndexStructures.obj
│   │       │   (more object files, omitted for brevity)
│   │       │   utils.obj
│   │       │   VectorTransform.obj
│   │       │   WorkerThread.obj
│   │       │
│   │       └───faiss.tlog (omitted for brevity)
│   │
│   └───Release
│           faiss.lib
│
└───x64 (this and other folders omitted for brevity)
```

But the build script was expecting `faiss_c.lib` to be directly inside of `build\c_api`, so the build fails. 
I also got rid of the part that explicitly sets `CMAKE_BUILD_TYPE` to `Release`. The default behavior of the `cmake` crate is to do builds that follow the cargo build mode automatically, and setting the `CMAKE_BUILD_TYPE` causes the configuration and the build stages to use different profiles. This could lead to confusion.