### PR TITLE
Change signature of RangeSearchResult.distance_and_labels_mut

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -426,7 +426,7 @@ impl RangeSearchResult {
 
     /// getter for labels and respective distances (not sorted):
     /// result for query `i` is `labels[lims[i] .. lims[i+1]]`
-    pub fn distance_and_labels_mut(&self) -> (&mut [f32], &mut [Idx]) {
+    pub fn distance_and_labels_mut(&mut self) -> (&mut [f32], &mut [Idx]) {
         unsafe {
             let buf_size = faiss_RangeSearchResult_buffer_size(self.inner);
             let mut distances_ptr = ptr::null_mut();


### PR DESCRIPTION
The method should taken `&mut self` from the beginning. Treating this as a breaking change though it's a bug. Fixes the error reported by Clippy.