### PR TITLE
Fix regression in gpu index impl method `to_cpu`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       # Build and run tests
       - name: Run tests
         run: cargo test --verbose
+      # Check that GPU modules compile
+      - name: Check GPU feature
+        run: cargo check --features=gpu
 
   # test `faiss` crates with static linking
   build-static:

--- a/src/index/gpu.rs
+++ b/src/index/gpu.rs
@@ -212,7 +212,7 @@ where
         unsafe {
             let mut cpuindex_ptr = ptr::null_mut();
             faiss_try(faiss_index_gpu_to_cpu(self.inner, &mut cpuindex_ptr))?;
-            Ok(I::from_inner_ptr(cpuindex_ptr))
+            Ok(I::from_inner_ptr(cpuindex_ptr as *mut I::Inner))
         }
     }
 


### PR DESCRIPTION
- Fix regression in index gpu impl: cast index pointer to the expected `Inner` associated type
- Add CI step to check code with gpu feature enabled
